### PR TITLE
MODTLR-6 Create TLR processing timer

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -29,6 +29,19 @@
           "pathPattern": "/_/tenant"
         }
       ]
+    },
+    {
+      "id": "_timer",
+      "version": "1.0",
+      "interfaceType": "system",
+      "handlers": [
+        {
+          "methods": [ "POST" ],
+          "pathPattern": "/title-level-requests-processing",
+          "unit": "second",
+          "delay": "30"
+        }
+      ]
     }
   ],
   "permissionSets" : [],

--- a/src/main/java/org/folio/controller/OpenRequestsProcessingController.java
+++ b/src/main/java/org/folio/controller/OpenRequestsProcessingController.java
@@ -1,0 +1,22 @@
+package org.folio.controller;
+
+import org.folio.service.OpenRequestsProcessingService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+public class OpenRequestsProcessingController {
+
+  private final OpenRequestsProcessingService openRequestsProcessingService;
+
+  @PostMapping(value = "/title-level-requests-processing")
+  public void processOpenRequests() {
+    openRequestsProcessingService.processOpenRequests();
+  }
+
+}

--- a/src/main/java/org/folio/service/OpenRequestsProcessingService.java
+++ b/src/main/java/org/folio/service/OpenRequestsProcessingService.java
@@ -1,0 +1,5 @@
+package org.folio.service;
+
+public interface OpenRequestsProcessingService {
+  void processOpenRequests();
+}

--- a/src/main/java/org/folio/service/impl/OpenRequestsProcessingServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/OpenRequestsProcessingServiceImpl.java
@@ -1,0 +1,19 @@
+package org.folio.service.impl;
+
+import org.folio.service.OpenRequestsProcessingService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class OpenRequestsProcessingServiceImpl implements OpenRequestsProcessingService {
+
+  @Override
+  public void processOpenRequests() {
+    log.info("processOpenRequests:: start");
+  }
+
+}

--- a/src/test/java/org/folio/api/OpenRequestsProcessingApiTest.java
+++ b/src/test/java/org/folio/api/OpenRequestsProcessingApiTest.java
@@ -1,0 +1,20 @@
+package org.folio.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class OpenRequestsProcessingApiTest extends BaseIT {
+  private static final String PROCESS_OPEN_REQUESTS_URL = "/title-level-requests-processing";
+
+  @Test
+  void getByIdNotFound() throws Exception {
+    mockMvc.perform(
+        post(PROCESS_OPEN_REQUESTS_URL)
+          .headers(defaultHeaders())
+          .contentType(MediaType.APPLICATION_JSON))
+      .andExpect(status().is2xxSuccessful());
+  }
+}

--- a/src/test/java/org/folio/controller/OpenRequestsProcessingControllerTest.java
+++ b/src/test/java/org/folio/controller/OpenRequestsProcessingControllerTest.java
@@ -1,0 +1,28 @@
+package org.folio.controller;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.folio.service.OpenRequestsProcessingService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenRequestsProcessingControllerTest {
+
+  @Mock
+  private OpenRequestsProcessingService service;
+
+  @InjectMocks
+  private OpenRequestsProcessingController controller;
+
+  @Test
+  void openRequestsProcessingServiceCalledFromController() {
+    controller.processOpenRequests();
+    verify(service, times(1)).processOpenRequests();
+  }
+
+}


### PR DESCRIPTION
## Purpose
To create a new timer (dummy, at the moment) to process open TLRs in the multitenant environment, which may require polling other modules in different tenants,

## Approach
Add a new timer, new endpoint, controller, service.

Ticket [MODTLR-6](https://issues.folio.org/browse/MODTLR-6)