### PR TITLE
[MODTLR-18] Implement retry creation on failure

### DIFF
--- a/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
@@ -3,7 +3,6 @@ package org.folio.domain.strategy;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.base.Predicates.notNull;
 import static java.util.Comparator.comparingLong;
-import static java.util.Map.Entry.comparingByValue;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
@@ -47,11 +46,11 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
       .sorted(
         comparingLong(
           (Map.Entry<String, Map<String, Long>> entry) -> countItems(entry, Set.of("Available")::contains))
-        .thenComparingLong(
-          (Map.Entry<String, Map<String, Long>> entry) -> countItems(entry,
-            Set.of("Checked out", "In transit")::contains))
-        .thenComparingLong((Map.Entry<String, Map<String, Long>> entry) -> countItems(
-          entry, alwaysTrue())))
+          .thenComparingLong(
+            (Map.Entry<String, Map<String, Long>> entry) -> countItems(entry,
+              Set.of("Checked out", "In transit")::contains))
+          .thenComparingLong((Map.Entry<String, Map<String, Long>> entry) -> countItems(
+            entry, alwaysTrue())))
       .map(Entry::getKey)
       .collect(Collectors.toCollection(LinkedHashSet::new));
 
@@ -91,17 +90,6 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
         .filter(notNull())
         .collect(groupingBy(identity(), counting()))
       ));
-  }
-
-  private static long countItems(Map.Entry<String, Map<String, Long>> itemStatuses,
-    Predicate<String> statusPredicate) {
-
-    return itemStatuses.getValue()
-      .entrySet()
-      .stream()
-      .filter(entry -> statusPredicate.test(entry.getKey()))
-      .map(Map.Entry::getValue)
-      .reduce(0L, Long::sum);
   }
 
   private static long countItems(Map.Entry<String, Map<String, Long>> itemStatuses,

--- a/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
@@ -55,9 +55,9 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
       .toList();
 
     if (sortedTenantIds.isEmpty()) {
-      log.warn("findTenants:: failed to find tenant for instance {}", instanceId);
+      log.warn("findTenants:: failed to find tenants for instance {}", instanceId);
     } else {
-      log.info("findTenants:: tenant for instance {} found: {}", instanceId, sortedTenantIds);
+      log.info("findTenants:: tenants for instance {} found: {}", instanceId, sortedTenantIds);
     }
 
     return sortedTenantIds;

--- a/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
@@ -49,7 +49,7 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
           .thenComparing(comparingLong((Entry<String, Map<String, Long>> entry) -> countItems(
             entry, s -> true)).reversed()))
       .map(Entry::getKey)
-      .collect(Collectors.toList());
+      .toList();
 
     if (sortedTenantIds.isEmpty()) {
       log.warn("pickTenant:: failed to pick tenant for instance {}", instanceId);

--- a/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
@@ -41,7 +41,7 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
 
   @Override
   public List<String> findTenants(String instanceId) {
-    log.info("findTenants:: picking tenants for a TLR for instance {}", instanceId);
+    log.info("findTenants:: find tenants for a TLR for instance {}", instanceId);
 
     var itemStatusOccurrencesByTenant = getItemStatusOccurrencesByTenant(instanceId);
     log.info("findTenants:: item status occurrences by tenant: {}", itemStatusOccurrencesByTenant);
@@ -55,7 +55,7 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
       .toList();
 
     if (sortedTenantIds.isEmpty()) {
-      log.warn("findTenants:: failed to pick tenant for instance {}", instanceId);
+      log.warn("findTenants:: failed to find tenant for instance {}", instanceId);
     } else {
       log.info("findTenants:: tenant for instance {} found: {}", instanceId, sortedTenantIds);
     }

--- a/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategy.java
@@ -2,31 +2,26 @@ package org.folio.domain.strategy;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.base.Predicates.notNull;
-import static java.util.Map.Entry.comparingByValue;
+import static java.util.Comparator.comparingLong;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
-import static org.folio.domain.dto.ItemStatusEnum.AVAILABLE;
-import static org.folio.domain.dto.ItemStatusEnum.CHECKED_OUT;
-import static org.folio.domain.dto.ItemStatusEnum.IN_TRANSIT;
 
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.folio.client.feign.SearchClient;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
-import org.folio.domain.dto.ItemStatusEnum;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
@@ -46,18 +41,26 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
     var itemStatusOccurrencesByTenant = getItemStatusOccurrencesByTenant(instanceId);
     log.info("pickTenant:: item status occurrences by tenant: {}", itemStatusOccurrencesByTenant);
 
-    Set<String> tenantIds = new LinkedHashSet<>();
-    pickTenant(itemStatusOccurrencesByTenant, EnumSet.of(AVAILABLE)).ifPresent(tenantIds::add);
-    pickTenant(itemStatusOccurrencesByTenant, EnumSet.of(CHECKED_OUT, IN_TRANSIT)).ifPresent(tenantIds::add);
-    pickTenant(itemStatusOccurrencesByTenant, alwaysTrue()).ifPresent(tenantIds::add);
+    Set<String> sortedTenantIds = itemStatusOccurrencesByTenant.entrySet()
+      .stream()
+      .sorted(
+        comparingLong(
+          (Map.Entry<String, Map<String, Long>> entry) -> countItems(entry, Set.of("Available")::contains))
+        .thenComparingLong(
+          (Map.Entry<String, Map<String, Long>> entry) -> countItems(entry,
+            Set.of("Checked out", "In transit")::contains))
+        .thenComparingLong((Map.Entry<String, Map<String, Long>> entry) -> countItems(
+          entry, alwaysTrue())))
+      .map(Entry::getKey)
+      .collect(Collectors.toCollection(LinkedHashSet::new));
 
-    if (tenantIds.isEmpty()) {
+    if (sortedTenantIds.isEmpty()) {
       log.warn("pickTenant:: failed to pick tenant for instance {}", instanceId);
     } else {
-      log.info("pickTenant:: tenant for instance {} found: {}", instanceId, tenantIds);
+      log.info("pickTenant:: tenant for instance {} found: {}", instanceId, sortedTenantIds);
     }
 
-    return tenantIds;
+    return sortedTenantIds;
   }
 
   private Map<String, Map<String, Long>> getItemStatusOccurrencesByTenant(String instanceId) {
@@ -89,34 +92,15 @@ public class ItemStatusBasedTenantPickingStrategy implements TenantPickingStrate
       ));
   }
 
-  private static Optional<String> pickTenant(Map<String, Map<String, Long>> statusOccurrencesByTenant,
-    EnumSet<ItemStatusEnum> desiredStatuses) {
+  private static long countItems(Map.Entry<String, Map<String, Long>> itemStatuses,
+    Predicate<String> statusPredicate) {
 
-    List<String> desiredStatusValues = desiredStatuses.stream()
-      .map(ItemStatusEnum::getValue)
-      .toList();
-
-    log.info("pickTenant:: looking for tenant with most items in statuses {}", desiredStatuses);
-    return pickTenant(statusOccurrencesByTenant, desiredStatusValues::contains);
-  }
-
-  private static Optional<String> pickTenant(Map<String, Map<String, Long>> statusOccurrencesByTenant,
-    Predicate<String> statusFilter) {
-
-    return statusOccurrencesByTenant.entrySet()
-      .stream()
-      .collect(toMap(Entry::getKey, entry -> entry.getValue()
-        .entrySet()
-        .stream()
-        .filter(subMapEntry -> statusFilter.test(subMapEntry.getKey()))
-        .map(Entry::getValue)
-        .reduce(0L, Long::sum)
-      ))
+    return itemStatuses.getValue()
       .entrySet()
       .stream()
-      .filter(entry -> entry.getValue() > 0)
-      .max(comparingByValue())
-      .map(Entry::getKey);
+      .filter(entry -> statusPredicate.test(entry.getKey()))
+      .map(Map.Entry::getValue)
+      .reduce(0L, Long::sum);
   }
 
 }

--- a/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
@@ -3,5 +3,5 @@ package org.folio.domain.strategy;
 import java.util.List;
 
 public interface TenantPickingStrategy {
-  List<String> pickTenants(String instanceId);
+  List<String> findTenants(String instanceId);
 }

--- a/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
@@ -1,7 +1,7 @@
 package org.folio.domain.strategy;
 
-import java.util.Set;
+import java.util.List;
 
 public interface TenantPickingStrategy {
-  Set<String> pickTenants(String instanceId);
+  List<String> pickTenants(String instanceId);
 }

--- a/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
@@ -1,8 +1,7 @@
 package org.folio.domain.strategy;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 public interface TenantPickingStrategy {
-  List<String> pickTenants(String instanceId);
+  Set<String> pickTenants(String instanceId);
 }

--- a/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
+++ b/src/main/java/org/folio/domain/strategy/TenantPickingStrategy.java
@@ -1,7 +1,8 @@
 package org.folio.domain.strategy;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TenantPickingStrategy {
-  Optional<String> pickTenant(String instanceId);
+  List<String> pickTenants(String instanceId);
 }

--- a/src/main/java/org/folio/exception/RequestCreatingException.java
+++ b/src/main/java/org/folio/exception/RequestCreatingException.java
@@ -1,0 +1,7 @@
+package org.folio.exception;
+
+public class RequestCreatingException extends RuntimeException {
+  public RequestCreatingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -10,7 +10,6 @@ import org.folio.domain.dto.Request;
 import org.folio.domain.mapper.EcsTlrMapper;
 import org.folio.domain.strategy.TenantPickingStrategy;
 import org.folio.exception.TenantPickingException;
-import org.folio.exception.TenantScopedExecutionException;
 import org.folio.repository.EcsTlrRepository;
 import org.folio.service.EcsTlrService;
 import org.folio.service.TenantScopedExecutionService;
@@ -47,12 +46,13 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     for (String tenantId : tenantIds) {
       try {
         return createRequest(ecsTlr, tenantId);
-      } catch (TenantScopedExecutionException e) {
-        log.error("create:: cannot create a request for tenantId: {}", tenantId);
+      } catch (Exception e) {
+        log.error("create:: cannot create a request for tenantId: {}, {}", tenantId, e.getMessage());
+        log.debug("create:: cannot create a request for tenantId: {}, {}", tenantId, e);
       }
     }
-    log.error("create:: failed to pick tenant for instance: {}", instanceId);
-    throw new TenantPickingException("Failed to pick tenant for instance " + instanceId);
+    log.error("create:: failed to find tenants for instance: {}", instanceId);
+    throw new TenantPickingException("Failed to find tenants for instance " + instanceId);
   }
 
   @Override

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -43,7 +43,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     log.debug("create:: parameters ecsTlr: {}", () -> ecsTlr);
     final String instanceId = ecsTlr.getInstanceId();
 
-    List<String> tenantIds = tenantPickingStrategy.pickTenants(instanceId);
+    List<String> tenantIds = tenantPickingStrategy.findTenants(instanceId);
     for (String tenantId : tenantIds) {
       try {
         return createRequest(ecsTlr, tenantId);

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -54,12 +54,12 @@ public class EcsTlrServiceImpl implements EcsTlrService {
       try {
         return createRequest(ecsTlr, tenantId);
       } catch (Exception e) {
-        log.error("create:: failed create a request for tenant {}: {}", tenantId, e.getMessage());
+        log.error("create:: failed to create a request for tenant {}: {}", tenantId, e.getMessage());
         log.debug("create:: ", e);
       }
     }
     throw new RequestCreatingException(format(
-      "Failed to create a request for instanceId: %s in tenants: %s", instanceId, tenantIds));
+      "Failed to create a request for instanceId %s in tenants %s", instanceId, tenantIds));
   }
 
   @Override

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -48,7 +48,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
         return createRequest(ecsTlr, tenantId);
       } catch (Exception e) {
         log.error("create:: cannot create a request for tenantId: {}, {}", tenantId, e.getMessage());
-        log.debug("create:: cannot create a request for tenantId: {}, {}", tenantId, e);
+        log.debug("create:: cannot create a request for tenantId: {}", tenantId, e);
       }
     }
     log.error("create:: failed to find tenants for instance: {}", instanceId);

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -1,7 +1,7 @@
 package org.folio.service.impl;
 
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.client.feign.CirculationClient;
@@ -43,7 +43,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     log.debug("create:: parameters ecsTlr: {}", () -> ecsTlr);
     final String instanceId = ecsTlr.getInstanceId();
 
-    List<String> tenantIds = tenantPickingStrategy.pickTenants(instanceId);
+    Set<String> tenantIds = tenantPickingStrategy.pickTenants(instanceId);
     for (String tenantId : tenantIds) {
       try {
         return createRequest(ecsTlr, tenantId);

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -1,7 +1,7 @@
 package org.folio.service.impl;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import org.folio.client.feign.CirculationClient;
@@ -43,7 +43,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     log.debug("create:: parameters ecsTlr: {}", () -> ecsTlr);
     final String instanceId = ecsTlr.getInstanceId();
 
-    Set<String> tenantIds = tenantPickingStrategy.pickTenants(instanceId);
+    List<String> tenantIds = tenantPickingStrategy.pickTenants(instanceId);
     for (String tenantId : tenantIds) {
       try {
         return createRequest(ecsTlr, tenantId);

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -62,7 +62,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
       Arguments.of(Set.of("a"), buildInstance(buildItem("a", "In transit"))),
       Arguments.of(Set.of("a"), buildInstance(buildItem("a", "Paged"))),
 
-      // multiple tenants, same item status, tenant should be sorted by number of items
+      // multiple tenants, same item status, tenants should be sorted by number of items
       Arguments.of(Set.of("b", "c", "a"), buildInstance(
         buildItem("a", "Available"),
         buildItem("b", "Available"),

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -5,6 +5,8 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -95,7 +97,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
       )),
 
       // item priority test: "Available" > ("Checked out" + "In transit") > all others
-      Arguments.of(Set.of("b", "c", "a"), buildInstance(
+      Arguments.of(new LinkedHashSet<>(List.of("b", "c", "a")), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),
@@ -103,7 +105,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Checked out"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(Set.of("c", "a"), buildInstance(
+      Arguments.of(new LinkedHashSet<>(List.of("c", "a")), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -36,7 +36,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
   void pickTenant(String expectedTenantId, Instance instance) {
     Mockito.when(searchClient.searchInstance(Mockito.any()))
       .thenReturn(new SearchInstancesResponse().instances(singletonList(instance)));
-    assertEquals(ofNullable(expectedTenantId), strategy.pickTenant(INSTANCE_ID));
+    assertEquals(ofNullable(expectedTenantId), strategy.pickTenants(INSTANCE_ID));
   }
 
   private static Stream<Arguments> parametersForPickTenant() {

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -62,8 +62,8 @@ class ItemStatusBasedTenantPickingStrategyTest {
       Arguments.of(Set.of("a"), buildInstance(buildItem("a", "In transit"))),
       Arguments.of(Set.of("a"), buildInstance(buildItem("a", "Paged"))),
 
-      // multiple tenants, same item status, tenant with most items wins
-      Arguments.of(Set.of("b"), buildInstance(
+      // multiple tenants, same item status, tenant should be sorted by number of items
+      Arguments.of(Set.of("b", "c", "a"), buildInstance(
         buildItem("a", "Available"),
         buildItem("b", "Available"),
         buildItem("b", "Available"),
@@ -71,15 +71,15 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Available"),
         buildItem("c", "Available")
       )),
-      Arguments.of(Set.of("b"), buildInstance(
+      Arguments.of(Set.of("a", "c", "b"), buildInstance(
         buildItem("a", "Checked out"),
-        buildItem("b", "Checked out"),
-        buildItem("b", "Checked out"),
+        buildItem("a", "Checked out"),
+        buildItem("a", "Checked out"),
         buildItem("b", "Checked out"),
         buildItem("c", "Checked out"),
         buildItem("c", "Checked out")
       )),
-      Arguments.of(Set.of("b"), buildInstance(
+      Arguments.of(Set.of("b", "c", "a"), buildInstance(
         buildItem("a", "In transit"),
         buildItem("b", "In transit"),
         buildItem("b", "In transit"),
@@ -87,11 +87,11 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "In transit"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(Set.of("b"), buildInstance(
+      Arguments.of(Set.of("c", "b", "a"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("b", "Paged"),
         buildItem("b", "Paged"),
-        buildItem("b", "Paged"),
+        buildItem("c", "Paged"),
         buildItem("c", "Paged"),
         buildItem("c", "Paged")
       )),
@@ -105,7 +105,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Checked out"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(new LinkedHashSet<>(List.of("c", "a")), buildInstance(
+      Arguments.of(new LinkedHashSet<>(List.of("b", "c", "a")), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),
@@ -119,7 +119,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "In transit"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(Set.of("a"), buildInstance(
+      Arguments.of(Set.of("a", "c", "b"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -37,7 +37,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
   void pickTenant(List<String> expectedTenantIds, Instance instance) {
     Mockito.when(searchClient.searchInstance(Mockito.any()))
       .thenReturn(new SearchInstancesResponse().instances(singletonList(instance)));
-    assertEquals(expectedTenantIds, strategy.pickTenants(INSTANCE_ID));
+    assertEquals(expectedTenantIds, strategy.findTenants(INSTANCE_ID));
   }
 
   private static Stream<Arguments> parametersForPickTenant() {

--- a/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
+++ b/src/test/java/org/folio/domain/strategy/ItemStatusBasedTenantPickingStrategyTest.java
@@ -1,13 +1,11 @@
 package org.folio.domain.strategy;
 
-import static java.util.Collections.emptySet;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -36,7 +34,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
 
   @ParameterizedTest
   @MethodSource("parametersForPickTenant")
-  void pickTenant(Set<String> expectedTenantIds, Instance instance) {
+  void pickTenant(List<String> expectedTenantIds, Instance instance) {
     Mockito.when(searchClient.searchInstance(Mockito.any()))
       .thenReturn(new SearchInstancesResponse().instances(singletonList(instance)));
     assertEquals(expectedTenantIds, strategy.pickTenants(INSTANCE_ID));
@@ -44,26 +42,26 @@ class ItemStatusBasedTenantPickingStrategyTest {
 
   private static Stream<Arguments> parametersForPickTenant() {
     return Stream.of(
-      Arguments.of(emptySet(), null),
+      Arguments.of(emptyList(), null),
 
       // instances without items are ignored
-      Arguments.of(emptySet(), buildInstance()),
+      Arguments.of(emptyList(), buildInstance()),
 
       // items without tenantId are ignored
-      Arguments.of(emptySet(), buildInstance(buildItem(null, "Available"))),
-      Arguments.of(Set.of("a"), buildInstance(
+      Arguments.of(emptyList(), buildInstance(buildItem(null, "Available"))),
+      Arguments.of(List.of("a"), buildInstance(
         buildItem(null, "Available"),
         buildItem("a", "Paged")
       )),
 
-      // 1 tenant, 1 item
-      Arguments.of(Set.of("a"), buildInstance(buildItem("a", "Available"))),
-      Arguments.of(Set.of("a"), buildInstance(buildItem("a", "Checked out"))),
-      Arguments.of(Set.of("a"), buildInstance(buildItem("a", "In transit"))),
-      Arguments.of(Set.of("a"), buildInstance(buildItem("a", "Paged"))),
+//       1 tenant, 1 item
+      Arguments.of(List.of("a"), buildInstance(buildItem("a", "Available"))),
+      Arguments.of(List.of("a"), buildInstance(buildItem("a", "Checked out"))),
+      Arguments.of(List.of("a"), buildInstance(buildItem("a", "In transit"))),
+      Arguments.of(List.of("a"), buildInstance(buildItem("a", "Paged"))),
 
       // multiple tenants, same item status, tenants should be sorted by number of items
-      Arguments.of(Set.of("b", "c", "a"), buildInstance(
+      Arguments.of(List.of("b", "c", "a"), buildInstance(
         buildItem("a", "Available"),
         buildItem("b", "Available"),
         buildItem("b", "Available"),
@@ -71,7 +69,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Available"),
         buildItem("c", "Available")
       )),
-      Arguments.of(Set.of("a", "c", "b"), buildInstance(
+      Arguments.of(List.of("a", "c", "b"), buildInstance(
         buildItem("a", "Checked out"),
         buildItem("a", "Checked out"),
         buildItem("a", "Checked out"),
@@ -79,7 +77,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Checked out"),
         buildItem("c", "Checked out")
       )),
-      Arguments.of(Set.of("b", "c", "a"), buildInstance(
+      Arguments.of(List.of("b", "c", "a"), buildInstance(
         buildItem("a", "In transit"),
         buildItem("b", "In transit"),
         buildItem("b", "In transit"),
@@ -87,7 +85,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "In transit"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(Set.of("c", "b", "a"), buildInstance(
+      Arguments.of(List.of("c", "b", "a"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("b", "Paged"),
         buildItem("b", "Paged"),
@@ -97,7 +95,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
       )),
 
       // item priority test: "Available" > ("Checked out" + "In transit") > all others
-      Arguments.of(new LinkedHashSet<>(List.of("b", "c", "a")), buildInstance(
+      Arguments.of(List.of("b", "c", "a"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),
@@ -105,7 +103,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "Checked out"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(new LinkedHashSet<>(List.of("b", "c", "a")), buildInstance(
+      Arguments.of(List.of("c", "b", "a"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),
@@ -119,7 +117,7 @@ class ItemStatusBasedTenantPickingStrategyTest {
         buildItem("c", "In transit"),
         buildItem("c", "In transit")
       )),
-      Arguments.of(Set.of("a", "c", "b"), buildInstance(
+      Arguments.of(List.of("a", "c", "b"), buildInstance(
         buildItem("a", "Paged"),
         buildItem("a", "Awaiting pickup"),
         buildItem("a", "Awaiting delivery"),

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -10,9 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import org.folio.domain.dto.EcsTlr;
@@ -93,7 +91,7 @@ class EcsTlrServiceTest {
 
     when(ecsTlrRepository.save(any(EcsTlrEntity.class))).thenReturn(mockEcsTlrEntity);
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(Set.of("random-tenant"));
+      .thenReturn(List.of("random-tenant"));
     when(tenantScopedExecutionService.execute(any(String.class), any()))
       .thenReturn(new Request().id(UUID.randomUUID().toString()));
     var postEcsTlr = ecsTlrService.create(ecsTlr);
@@ -120,7 +118,7 @@ class EcsTlrServiceTest {
   @Test
   void canNotCreateRemoteRequestWhenFailedToPickTenant() {
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(Collections.emptySet());
+      .thenReturn(Collections.emptyList());
     String instanceId = UUID.randomUUID().toString();
     EcsTlr ecsTlr = new EcsTlr().instanceId(instanceId);
 
@@ -140,8 +138,8 @@ class EcsTlrServiceTest {
     String secondTenantId = UUID.randomUUID().toString();
     String thirdTenantId = UUID.randomUUID().toString();
 
-    Set<String> mockTenantIds = new LinkedHashSet<>(List.of(
-      firstTenantId, secondTenantId, thirdTenantId));
+    List<String> mockTenantIds = List.of(
+      firstTenantId, secondTenantId, thirdTenantId);
     when(tenantPickingStrategy.pickTenants(any(String.class)))
       .thenReturn(mockTenantIds);
     when(tenantScopedExecutionService.execute(any(), any()))

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -90,7 +90,7 @@ class EcsTlrServiceTest {
     ecsTlr.setPickupServicePointId(pickupServicePointId.toString());
 
     when(ecsTlrRepository.save(any(EcsTlrEntity.class))).thenReturn(mockEcsTlrEntity);
-    when(tenantPickingStrategy.pickTenants(any(String.class)))
+    when(tenantPickingStrategy.findTenants(any(String.class)))
       .thenReturn(List.of("random-tenant"));
     when(tenantScopedExecutionService.execute(any(String.class), any()))
       .thenReturn(new Request().id(UUID.randomUUID().toString()));
@@ -117,7 +117,7 @@ class EcsTlrServiceTest {
 
   @Test
   void canNotCreateRemoteRequestWhenFailedToPickTenant() {
-    when(tenantPickingStrategy.pickTenants(any(String.class)))
+    when(tenantPickingStrategy.findTenants(any(String.class)))
       .thenReturn(Collections.emptyList());
     String instanceId = UUID.randomUUID().toString();
     EcsTlr ecsTlr = new EcsTlr().instanceId(instanceId);
@@ -140,7 +140,7 @@ class EcsTlrServiceTest {
 
     List<String> mockTenantIds = List.of(
       firstTenantId, secondTenantId, thirdTenantId);
-    when(tenantPickingStrategy.pickTenants(any(String.class)))
+    when(tenantPickingStrategy.findTenants(any(String.class)))
       .thenReturn(mockTenantIds);
     when(tenantScopedExecutionService.execute(any(), any()))
       .thenThrow(new TenantScopedExecutionException(new RuntimeException("Test failure"), firstTenantId))

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.domain.dto.EcsTlr;
@@ -91,7 +91,7 @@ class EcsTlrServiceTest {
 
     when(ecsTlrRepository.save(any(EcsTlrEntity.class))).thenReturn(mockEcsTlrEntity);
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(List.of("random-tenant"));
+      .thenReturn(Set.of("random-tenant"));
     when(tenantScopedExecutionService.execute(any(String.class), any()))
       .thenReturn(new Request().id(UUID.randomUUID().toString()));
     var postEcsTlr = ecsTlrService.create(ecsTlr);
@@ -118,7 +118,7 @@ class EcsTlrServiceTest {
   @Test
   void canNotCreateRemoteRequestWhenFailedToPickTenant() {
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(Collections.emptyList());
+      .thenReturn(Collections.emptySet());
     String instanceId = UUID.randomUUID().toString();
     EcsTlr ecsTlr = new EcsTlr().instanceId(instanceId);
 
@@ -139,7 +139,7 @@ class EcsTlrServiceTest {
     String thirdTenantId = UUID.randomUUID().toString();
 
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(List.of(firstTenantId, secondTenantId, thirdTenantId));
+      .thenReturn(Set.of(firstTenantId, secondTenantId, thirdTenantId));
     when(tenantScopedExecutionService.execute(any(), any()))
       .thenThrow(new TenantScopedExecutionException(new RuntimeException("Test failure"), firstTenantId))
       .thenReturn(new Request().id(UUID.randomUUID().toString()))

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -125,7 +125,7 @@ class EcsTlrServiceTest {
     TenantPickingException exception = assertThrows(TenantPickingException.class,
       () -> ecsTlrService.create(ecsTlr));
 
-    assertEquals("Failed to pick tenant for instance " + instanceId, exception.getMessage());
+    assertEquals("Failed to find tenants for instance " + instanceId, exception.getMessage());
   }
 
   @Test

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -138,8 +140,10 @@ class EcsTlrServiceTest {
     String secondTenantId = UUID.randomUUID().toString();
     String thirdTenantId = UUID.randomUUID().toString();
 
+    Set<String> mockTenantIds = new LinkedHashSet<>(List.of(
+      firstTenantId, secondTenantId, thirdTenantId));
     when(tenantPickingStrategy.pickTenants(any(String.class)))
-      .thenReturn(Set.of(firstTenantId, secondTenantId, thirdTenantId));
+      .thenReturn(mockTenantIds);
     when(tenantScopedExecutionService.execute(any(), any()))
       .thenThrow(new TenantScopedExecutionException(new RuntimeException("Test failure"), firstTenantId))
       .thenReturn(new Request().id(UUID.randomUUID().toString()))

--- a/src/test/java/org/folio/service/EcsTlrServiceTest.java
+++ b/src/test/java/org/folio/service/EcsTlrServiceTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.folio.domain.dto.EcsTlr;
@@ -18,11 +20,13 @@ import org.folio.domain.mapper.EcsTlrMapper;
 import org.folio.domain.mapper.EcsTlrMapperImpl;
 import org.folio.domain.strategy.TenantPickingStrategy;
 import org.folio.exception.TenantPickingException;
+import org.folio.exception.TenantScopedExecutionException;
 import org.folio.repository.EcsTlrRepository;
 import org.folio.service.impl.EcsTlrServiceImpl;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -86,8 +90,8 @@ class EcsTlrServiceTest {
     ecsTlr.setPickupServicePointId(pickupServicePointId.toString());
 
     when(ecsTlrRepository.save(any(EcsTlrEntity.class))).thenReturn(mockEcsTlrEntity);
-    when(tenantPickingStrategy.pickTenant(any(String.class)))
-      .thenReturn(Optional.of("random-tenant"));
+    when(tenantPickingStrategy.pickTenants(any(String.class)))
+      .thenReturn(List.of("random-tenant"));
     when(tenantScopedExecutionService.execute(any(String.class), any()))
       .thenReturn(new Request().id(UUID.randomUUID().toString()));
     var postEcsTlr = ecsTlrService.create(ecsTlr);
@@ -113,8 +117,8 @@ class EcsTlrServiceTest {
 
   @Test
   void canNotCreateRemoteRequestWhenFailedToPickTenant() {
-    when(tenantPickingStrategy.pickTenant(any(String.class)))
-      .thenReturn(Optional.empty());
+    when(tenantPickingStrategy.pickTenants(any(String.class)))
+      .thenReturn(Collections.emptyList());
     String instanceId = UUID.randomUUID().toString();
     EcsTlr ecsTlr = new EcsTlr().instanceId(instanceId);
 
@@ -122,5 +126,28 @@ class EcsTlrServiceTest {
       () -> ecsTlrService.create(ecsTlr));
 
     assertEquals("Failed to pick tenant for instance " + instanceId, exception.getMessage());
+  }
+
+  @Test
+  void canCreateRemoteRequestOnlyForSecondTenantId() {
+    String instanceId = UUID.randomUUID().toString();
+    EcsTlr ecsTlr = new EcsTlr()
+      .instanceId(instanceId)
+      .id(UUID.randomUUID().toString());
+    String firstTenantId = UUID.randomUUID().toString();
+    String secondTenantId = UUID.randomUUID().toString();
+    String thirdTenantId = UUID.randomUUID().toString();
+
+    when(tenantPickingStrategy.pickTenants(any(String.class)))
+      .thenReturn(List.of(firstTenantId, secondTenantId, thirdTenantId));
+    when(tenantScopedExecutionService.execute(any(), any()))
+      .thenThrow(new TenantScopedExecutionException(new RuntimeException("Test failure"), firstTenantId))
+      .thenReturn(new Request().id(UUID.randomUUID().toString()))
+      .thenReturn(new Request().id(UUID.randomUUID().toString()));
+    ecsTlrService.create(ecsTlr);
+
+    ArgumentCaptor<EcsTlrEntity> captor = ArgumentCaptor.forClass(EcsTlrEntity.class);
+    verify(ecsTlrRepository, times(1)).save(captor.capture());
+    assertEquals(secondTenantId, captor.getValue().getSecondaryRequestTenantId());
   }
 }


### PR DESCRIPTION
## Purpose
MODTLR-11 creates a secondary TLR in the data tenant (lending side).
In scope of this ticket:
In case of a failure, select the next tenant using the same priority described in MODTLR-11.
Attempt to create a TLR in the selected tenant.
Repeat until TLR is successfully created or until there are no more tenants.

Resolves: [MODTLR-18](https://folio-org.atlassian.net/browse/MODTLR-18)
