### PR TITLE
MODTLR-27 Remove unneeded fields from the requester copy, update group

### DIFF
--- a/src/main/java/org/folio/client/feign/UsersClient.java
+++ b/src/main/java/org/folio/client/feign/UsersClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "users", url = "users", configuration = FeignClientConfiguration.class)
@@ -17,4 +18,7 @@ public interface UsersClient {
 
   @GetMapping("/{userId}")
   User getUser(@PathVariable String userId);
+
+  @PutMapping("/{userId}")
+  User putUser(@PathVariable String userId, @RequestBody User user);
 }

--- a/src/main/resources/swagger.api/schemas/user.json
+++ b/src/main/resources/swagger.api/schemas/user.json
@@ -5,16 +5,8 @@
   "javaName": "User",
   "type": "object",
   "properties": {
-    "username": {
-      "description": "A unique name belonging to a user. Typically used for login",
-      "type": "string"
-    },
     "id": {
       "description" : "A globally unique (UUID) identifier for the user",
-      "type": "string"
-    },
-    "externalSystemId": {
-      "description": "A unique ID that corresponds to an external authority",
       "type": "string"
     },
     "barcode": {
@@ -25,167 +17,10 @@
       "description": "A flag to determine if the user's account is effective and not expired. The tenant configuration can require the user to be active for login. Active is different from the loan patron block",
       "type": "boolean"
     },
-    "type": {
-      "description": "The class of user like staff or patron; this is different from patronGroup; it can store shadow, system user and dcb types also",
-      "type": "string"
-    },
     "patronGroup": {
       "description": "A UUID corresponding to the group the user belongs to, see /groups API, example groups are undergraduate and faculty; loan rules, patron blocks, fees/fines and expiration days can use the patron group",
       "type": "string",
       "$ref": "uuid.json"
-    },
-    "departments": {
-      "description": "A list of UUIDs corresponding to the departments the user belongs to, see /departments API",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "$ref": "uuid.json"
-      }
-    },
-    "meta": {
-      "description": "Deprecated",
-      "type": "object"
-    },
-    "proxyFor": {
-      "description" : "Deprecated",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "personal": {
-      "description": "Personal information about the user",
-      "type": "object",
-      "properties": {
-        "lastName": {
-          "description": "The user's surname",
-          "type": "string"
-        },
-        "firstName": {
-          "description": "The user's given name",
-          "type": "string"
-        },
-        "middleName": {
-          "description": "The user's middle name (if any)",
-          "type": "string"
-        },
-        "preferredFirstName": {
-          "description": "The user's preferred name",
-          "type": "string"
-        },
-        "email": {
-          "description": "The user's email address",
-          "type": "string"
-        },
-        "phone": {
-          "description": "The user's primary phone number",
-          "type": "string"
-        },
-        "mobilePhone": {
-          "description": "The user's mobile phone number",
-          "type": "string"
-        },
-        "dateOfBirth": {
-          "type": "string",
-          "description": "The user's birth date",
-          "format": "date-time"
-        },
-        "addresses": {
-          "description": "Physical addresses associated with the user",
-          "type": "array",
-          "minItems": 0,
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "description": "A unique id for this address",
-                "type": "string"
-              },
-              "countryId": {
-                "description": "The country code for this address",
-                "type": "string"
-              },
-              "addressLine1": {
-                "description": "Address, Line 1",
-                "type": "string"
-              },
-              "addressLine2": {
-                "description": "Address, Line 2",
-                "type": "string"
-              },
-              "city": {
-                "description": "City name",
-                "type": "string"
-              },
-              "region": {
-                "description": "Region",
-                "type": "string"
-              },
-              "postalCode": {
-                "description": "Postal Code",
-                "type": "string"
-              },
-              "addressTypeId": {
-                "description": "A UUID that corresponds with an address type object",
-                "type": "string",
-                "$ref": "uuid.json"
-              },
-              "primaryAddress": {
-                "description": "Is this the user's primary address?",
-                "type": "boolean"
-              }
-            },
-            "required":[
-              "addressTypeId"
-            ]
-          }
-        },
-        "preferredContactTypeId": {
-          "description": "Id of user's preferred contact type like Email, Mail or Text Message, see /addresstypes API",
-          "type": "string"
-        },
-        "profilePictureLink": {
-          "description": "Link to the profile picture",
-          "type": "string",
-          "format": "uri"
-        }
-      },
-      "required": [
-        "lastName"
-      ]
-    },
-    "enrollmentDate": {
-      "description": "The date in which the user joined the organization",
-      "type": "string",
-      "format": "date-time"
-    },
-    "expirationDate": {
-      "description": "The date for when the user becomes inactive",
-      "type": "string",
-      "format": "date-time"
-    },
-    "createdDate": {
-      "description": "Deprecated",
-      "type": "string",
-      "format": "date-time"
-    },
-    "updatedDate": {
-      "description": "Deprecated",
-      "type": "string",
-      "format": "date-time"
-    },
-    "metadata": {
-      "type": "object",
-      "$ref": "metadata.json"
-    },
-    "tags": {
-      "type": "object",
-      "$ref": "tags.json"
-    },
-    "customFields" : {
-      "description": "Object that contains custom field",
-      "type": "object"
     }
   }
 }

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -24,8 +24,6 @@ import org.folio.domain.dto.ItemStatus;
 import org.folio.domain.dto.Request;
 import org.folio.domain.dto.SearchInstancesResponse;
 import org.folio.domain.dto.User;
-import org.folio.domain.dto.UserPersonal;
-import org.folio.domain.dto.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -163,7 +161,7 @@ class EcsTlrApiTest extends BaseIT {
       .withRequestBody(equalToJson(asJsonString(mockPrimaryRequestResponse))));
 
     if (shadowUserExists) {
-      wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL)));
+      wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
     } else {
       wireMockServer.verify(postRequestedFor(urlMatching(USERS_URL))
         .withHeader(TENANT_HEADER, equalTo(TENANT_ID_COLLEGE))
@@ -251,33 +249,18 @@ class EcsTlrApiTest extends BaseIT {
   private static User buildUser(String userId) {
     return new User()
       .id(userId)
-      .username("test_user")
       .patronGroup(randomId())
-      .type("patron")
-      .active(true)
-      .personal(new UserPersonal()
-        .firstName("First")
-        .middleName("Middle")
-        .lastName("Last"));
+      .barcode("123")
+      .active(true);
   }
 
   private static User buildShadowUser(User realUser) {
-    User shadowUser = new User()
+
+    return new User()
       .id(realUser.getId())
-      .username(realUser.getUsername())
       .patronGroup(realUser.getPatronGroup())
-      .type(UserType.SHADOW.getValue())
+      .barcode(realUser.getBarcode())
       .active(true);
-
-    UserPersonal personal = realUser.getPersonal();
-    if (personal != null) {
-      shadowUser.setPersonal(new UserPersonal()
-        .firstName(personal.getFirstName())
-        .lastName(personal.getLastName())
-      );
-    }
-
-    return shadowUser;
   }
 
 }


### PR DESCRIPTION
Covers: [MODTLR-27](https://folio-org.atlassian.net/browse/MODTLR-27)

## Purpose
When creating requester copy in data tenant use only required fields:
* UUID
* barcode
* patron group
