### PR TITLE
MODTLR-27 Remove unneeded fields from the requester copy, update group

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,7 +23,6 @@
             "users.item.get",
             "users.collection.get",
             "users.item.post",
-            "users.item.put",
             "inventory-storage.service-points.item.get",
             "inventory-storage.service-points.collection.get",
             "inventory-storage.service-points.item.post"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,6 +23,7 @@
             "users.item.get",
             "users.collection.get",
             "users.item.post",
+            "users.item.put",
             "inventory-storage.service-points.item.get",
             "inventory-storage.service-points.collection.get",
             "inventory-storage.service-points.item.post"

--- a/src/main/java/org/folio/client/feign/UserClient.java
+++ b/src/main/java/org/folio/client/feign/UserClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "users", url = "users", configuration = FeignClientConfiguration.class)
@@ -17,4 +18,7 @@ public interface UserClient {
 
   @GetMapping("/{userId}")
   User getUser(@PathVariable String userId);
+
+  @PutMapping("/{userId}")
+  User putUser(@PathVariable String userId, @RequestBody User user);
 }

--- a/src/main/java/org/folio/service/UserService.java
+++ b/src/main/java/org/folio/service/UserService.java
@@ -5,4 +5,5 @@ import org.folio.domain.dto.User;
 public interface UserService {
   User find(String userId);
   User create(User user);
+  User update(User user);
 }

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -99,6 +99,7 @@ public class RequestServiceImpl implements RequestService {
   private void cloneRequester(User primaryRequestRequester) {
     User shadowUser = userCloningService.clone(primaryRequestRequester);
     String patronGroup = primaryRequestRequester.getPatronGroup();
+
     if (patronGroup != null && !patronGroup.equals(shadowUser.getPatronGroup())) {
       log.debug("cloneRequester:: updating requesters'({}) patron group in lending tenant to {}",
         shadowUser.getId(), primaryRequestRequester.getPatronGroup());

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -69,7 +69,8 @@ public class RequestServiceImpl implements RequestService {
             requesterId, lendingTenantId);
           User shadowUser = userCloningService.clone(primaryRequestRequester);
 
-          if(!primaryRequestRequester.getPatronGroup().equals(shadowUser.getPatronGroup())) {
+          if (primaryRequestRequester.getPatronGroup() != null &&
+            !primaryRequestRequester.getPatronGroup().equals(shadowUser.getPatronGroup())) {
             shadowUser.setPatronGroup(primaryRequestRequester.getPatronGroup());
             userService.update(shadowUser);
           }

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -67,13 +67,7 @@ public class RequestServiceImpl implements RequestService {
         return executionService.executeSystemUserScoped(lendingTenantId, () -> {
           log.info("createSecondaryRequest:: creating requester {} in lending tenant ({})",
             requesterId, lendingTenantId);
-          User shadowUser = userCloningService.clone(primaryRequestRequester);
-
-          if (primaryRequestRequester.getPatronGroup() != null &&
-            !primaryRequestRequester.getPatronGroup().equals(shadowUser.getPatronGroup())) {
-            shadowUser.setPatronGroup(primaryRequestRequester.getPatronGroup());
-            userService.update(shadowUser);
-          }
+          cloneRequester(primaryRequestRequester);
 
           log.info("createSecondaryRequest:: creating pickup service point {} in lending tenant ({})",
             pickupServicePointId, lendingTenantId);
@@ -100,6 +94,17 @@ public class RequestServiceImpl implements RequestService {
       request.getInstanceId(), lendingTenantIds);
     log.error("createSecondaryRequest:: {}", errorMessage);
     throw new RequestCreatingException(errorMessage);
+  }
+
+  private void cloneRequester(User primaryRequestRequester) {
+    User shadowUser = userCloningService.clone(primaryRequestRequester);
+    String patronGroup = primaryRequestRequester.getPatronGroup();
+    if (patronGroup != null && !patronGroup.equals(shadowUser.getPatronGroup())) {
+      log.debug("cloneRequester:: updating requesters'({}) patron group in lending tenant to {}",
+        shadowUser.getId(), primaryRequestRequester.getPatronGroup());
+      shadowUser.setPatronGroup(patronGroup);
+      userService.update(shadowUser);
+    }
   }
 
 }

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -67,7 +67,12 @@ public class RequestServiceImpl implements RequestService {
         return executionService.executeSystemUserScoped(lendingTenantId, () -> {
           log.info("createSecondaryRequest:: creating requester {} in lending tenant ({})",
             requesterId, lendingTenantId);
-          userCloningService.clone(primaryRequestRequester);
+          User shadowUser = userCloningService.clone(primaryRequestRequester);
+
+          if(!primaryRequestRequester.getPatronGroup().equals(shadowUser.getPatronGroup())) {
+            shadowUser.setPatronGroup(primaryRequestRequester.getPatronGroup());
+            userService.update(shadowUser);
+          }
 
           log.info("createSecondaryRequest:: creating pickup service point {} in lending tenant ({})",
             pickupServicePointId, lendingTenantId);

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -101,8 +101,8 @@ public class RequestServiceImpl implements RequestService {
     String patronGroup = primaryRequestRequester.getPatronGroup();
 
     if (patronGroup != null && !patronGroup.equals(shadowUser.getPatronGroup())) {
-      log.debug("cloneRequester:: updating requesters'({}) patron group in lending tenant to {}",
-        shadowUser.getId(), primaryRequestRequester.getPatronGroup());
+      log.info("cloneRequester:: updating requester's ({}) patron group in lending tenant to {}",
+        shadowUser.getId(), patronGroup);
       shadowUser.setPatronGroup(patronGroup);
       userService.update(shadowUser);
     }

--- a/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.service.impl;
 
 import org.folio.domain.dto.User;
+import org.folio.domain.dto.UserType;
 import org.folio.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class UserCloningServiceImpl extends CloningServiceImpl<User> {
     User clone = new User()
       .id(original.getId())
       .patronGroup(original.getPatronGroup())
+      .type(UserType.SHADOW.getValue())
       .barcode(original.getBarcode())
       .active(true);
     log.debug("buildClone:: result: {}", () -> clone);

--- a/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
@@ -1,8 +1,6 @@
 package org.folio.service.impl;
 
 import org.folio.domain.dto.User;
-import org.folio.domain.dto.UserPersonal;
-import org.folio.domain.dto.UserType;
 import org.folio.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,16 +34,8 @@ public class UserCloningServiceImpl extends CloningServiceImpl<User> {
     User clone = new User()
       .id(original.getId())
       .patronGroup(original.getPatronGroup())
-      .type(UserType.SHADOW.getValue())
+      .barcode(original.getBarcode())
       .active(true);
-
-    UserPersonal personal = original.getPersonal();
-    if (personal != null) {
-      clone.setPersonal(new UserPersonal()
-        .firstName(personal.getFirstName())
-        .lastName(personal.getLastName())
-      );
-    }
     log.debug("buildClone:: result: {}", () -> clone);
     return clone;
   }

--- a/src/main/java/org/folio/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/UserServiceImpl.java
@@ -29,7 +29,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public User update(User user) {
-    log.info("update:: updating user {}", user);
+    log.info("update:: updating user {}", user.getId());
     return userClient.putUser(user.getId(), user);
   }
 

--- a/src/main/java/org/folio/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/UserServiceImpl.java
@@ -27,4 +27,10 @@ public class UserServiceImpl implements UserService {
     return userClient.postUser(user);
   }
 
+  @Override
+  public User update(User user) {
+    log.info("update:: updating user {}", user);
+    return userClient.putUser(user.getId(), user);
+  }
+
 }

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -1,6 +1,7 @@
 users.collection.get
 users.item.get
 users.item.post
+users.item.put
 search.instances.collection.get
 circulation.requests.instances.item.post
 circulation.requests.item.post

--- a/src/main/resources/swagger.api/schemas/user.json
+++ b/src/main/resources/swagger.api/schemas/user.json
@@ -5,6 +5,10 @@
   "javaName": "User",
   "type": "object",
   "properties": {
+    "username": {
+      "description": "A unique name belonging to a user. Typically used for login",
+      "type": "string"
+    },
     "id": {
       "description" : "A globally unique (UUID) identifier for the user",
       "type": "string"
@@ -17,10 +21,35 @@
       "description": "A flag to determine if the user's account is effective and not expired. The tenant configuration can require the user to be active for login. Active is different from the loan patron block",
       "type": "boolean"
     },
+    "type": {
+      "description": "The class of user like staff or patron; this is different from patronGroup; it can store shadow, system user and dcb types also",
+      "type": "string"
+    },
     "patronGroup": {
       "description": "A UUID corresponding to the group the user belongs to, see /groups API, example groups are undergraduate and faculty; loan rules, patron blocks, fees/fines and expiration days can use the patron group",
       "type": "string",
       "$ref": "uuid.json"
+    },
+    "personal": {
+      "description": "Personal information about the user",
+      "type": "object",
+      "properties": {
+        "lastName": {
+          "description": "The user's surname",
+          "type": "string"
+        },
+        "firstName": {
+          "description": "The user's given name",
+          "type": "string"
+        },
+        "middleName": {
+          "description": "The user's middle name (if any)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "lastName"
+      ]
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/user.json
+++ b/src/main/resources/swagger.api/schemas/user.json
@@ -5,16 +5,8 @@
   "javaName": "User",
   "type": "object",
   "properties": {
-    "username": {
-      "description": "A unique name belonging to a user. Typically used for login",
-      "type": "string"
-    },
     "id": {
       "description" : "A globally unique (UUID) identifier for the user",
-      "type": "string"
-    },
-    "externalSystemId": {
-      "description": "A unique ID that corresponds to an external authority",
       "type": "string"
     },
     "barcode": {
@@ -25,167 +17,10 @@
       "description": "A flag to determine if the user's account is effective and not expired. The tenant configuration can require the user to be active for login. Active is different from the loan patron block",
       "type": "boolean"
     },
-    "type": {
-      "description": "The class of user like staff or patron; this is different from patronGroup; it can store shadow, system user and dcb types also",
-      "type": "string"
-    },
     "patronGroup": {
       "description": "A UUID corresponding to the group the user belongs to, see /groups API, example groups are undergraduate and faculty; loan rules, patron blocks, fees/fines and expiration days can use the patron group",
       "type": "string",
       "$ref": "uuid.json"
-    },
-    "departments": {
-      "description": "A list of UUIDs corresponding to the departments the user belongs to, see /departments API",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "$ref": "uuid.json"
-      }
-    },
-    "meta": {
-      "description": "Deprecated",
-      "type": "object"
-    },
-    "proxyFor": {
-      "description" : "Deprecated",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "personal": {
-      "description": "Personal information about the user",
-      "type": "object",
-      "properties": {
-        "lastName": {
-          "description": "The user's surname",
-          "type": "string"
-        },
-        "firstName": {
-          "description": "The user's given name",
-          "type": "string"
-        },
-        "middleName": {
-          "description": "The user's middle name (if any)",
-          "type": "string"
-        },
-        "preferredFirstName": {
-          "description": "The user's preferred name",
-          "type": "string"
-        },
-        "email": {
-          "description": "The user's email address",
-          "type": "string"
-        },
-        "phone": {
-          "description": "The user's primary phone number",
-          "type": "string"
-        },
-        "mobilePhone": {
-          "description": "The user's mobile phone number",
-          "type": "string"
-        },
-        "dateOfBirth": {
-          "type": "string",
-          "description": "The user's birth date",
-          "format": "date-time"
-        },
-        "addresses": {
-          "description": "Physical addresses associated with the user",
-          "type": "array",
-          "minItems": 0,
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "description": "A unique id for this address",
-                "type": "string"
-              },
-              "countryId": {
-                "description": "The country code for this address",
-                "type": "string"
-              },
-              "addressLine1": {
-                "description": "Address, Line 1",
-                "type": "string"
-              },
-              "addressLine2": {
-                "description": "Address, Line 2",
-                "type": "string"
-              },
-              "city": {
-                "description": "City name",
-                "type": "string"
-              },
-              "region": {
-                "description": "Region",
-                "type": "string"
-              },
-              "postalCode": {
-                "description": "Postal Code",
-                "type": "string"
-              },
-              "addressTypeId": {
-                "description": "A UUID that corresponds with an address type object",
-                "type": "string",
-                "$ref": "uuid.json"
-              },
-              "primaryAddress": {
-                "description": "Is this the user's primary address?",
-                "type": "boolean"
-              }
-            },
-            "required":[
-              "addressTypeId"
-            ]
-          }
-        },
-        "preferredContactTypeId": {
-          "description": "Id of user's preferred contact type like Email, Mail or Text Message, see /addresstypes API",
-          "type": "string"
-        },
-        "profilePictureLink": {
-          "description": "Link to the profile picture",
-          "type": "string",
-          "format": "uri"
-        }
-      },
-      "required": [
-        "lastName"
-      ]
-    },
-    "enrollmentDate": {
-      "description": "The date in which the user joined the organization",
-      "type": "string",
-      "format": "date-time"
-    },
-    "expirationDate": {
-      "description": "The date for when the user becomes inactive",
-      "type": "string",
-      "format": "date-time"
-    },
-    "createdDate": {
-      "description": "Deprecated",
-      "type": "string",
-      "format": "date-time"
-    },
-    "updatedDate": {
-      "description": "Deprecated",
-      "type": "string",
-      "format": "date-time"
-    },
-    "metadata": {
-      "type": "object",
-      "$ref": "metadata.json"
-    },
-    "tags": {
-      "type": "object",
-      "$ref": "tags.json"
-    },
-    "customFields" : {
-      "description": "Object that contains custom field",
-      "type": "object"
     }
   }
 }

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -368,6 +368,7 @@ class EcsTlrApiTest extends BaseIT {
 
   private static User buildSecondaryRequestRequester(User primaryRequestRequester,
     boolean secondaryRequestRequesterExists) {
+    
     return new User()
       .id(primaryRequestRequester.getId())
       .patronGroup(secondaryRequestRequesterExists ? PATRON_GROUP_ID_SECONDARY : PATRON_GROUP_ID_PRIMARY)

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -29,6 +29,7 @@ import org.folio.domain.dto.Request;
 import org.folio.domain.dto.SearchInstancesResponse;
 import org.folio.domain.dto.ServicePoint;
 import org.folio.domain.dto.User;
+import org.folio.domain.dto.UserPersonal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -353,9 +354,15 @@ class EcsTlrApiTest extends BaseIT {
   private static User buildPrimaryRequestRequester(String userId) {
     return new User()
       .id(userId)
+      .username("test_user")
       .patronGroup(PATRON_GROUP_ID_PRIMARY)
+      .type("patron")
+      .active(true)
       .barcode(REQUESTER_BARCODE)
-      .active(true);
+      .personal(new UserPersonal()
+        .firstName("First")
+        .middleName("Middle")
+        .lastName("Last"));
   }
 
   private static User buildSecondaryRequestRequester(User primaryRequestRequester,

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -30,6 +30,7 @@ import org.folio.domain.dto.SearchInstancesResponse;
 import org.folio.domain.dto.ServicePoint;
 import org.folio.domain.dto.User;
 import org.folio.domain.dto.UserPersonal;
+import org.folio.domain.dto.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -370,6 +371,7 @@ class EcsTlrApiTest extends BaseIT {
     return new User()
       .id(primaryRequestRequester.getId())
       .patronGroup(secondaryRequestRequesterExists ? PATRON_GROUP_ID_SECONDARY : PATRON_GROUP_ID_PRIMARY)
+      .type(UserType.SHADOW.getValue())
       .barcode(primaryRequestRequester.getBarcode())
       .active(true);
   }


### PR DESCRIPTION
Covers: [MODTLR-27](https://folio-org.atlassian.net/browse/MODTLR-27) 

## Purpose
Before placing a request in the data tenant, mod-tlr creates a requester copy in that tenant. This copy should contain only
required fields: UUID, barcode, patron group