### PR TITLE
MODTLR-31: Add `ecsRequestPhase` to primary and secondary requests

### DIFF
--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -48,7 +48,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     String borrowingTenantId = getBorrowingTenant(ecsTlr);
     Collection<String> lendingTenantIds = getLendingTenants(ecsTlr);
     RequestWrapper secondaryRequest = requestService.createSecondaryRequest(
-      requestsMapper.mapDtoToRequest(ecsTlr), borrowingTenantId, lendingTenantIds);
+      buildSecondaryRequest(ecsTlr), borrowingTenantId, lendingTenantIds);
     RequestWrapper primaryRequest = requestService.createPrimaryRequest(
       buildPrimaryRequest(secondaryRequest.request()), borrowingTenantId);
     updateEcsTlr(ecsTlr, primaryRequest, secondaryRequest);
@@ -117,8 +117,14 @@ public class EcsTlrServiceImpl implements EcsTlrService {
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)
       .requestType(Request.RequestTypeEnum.HOLD)
+      .ecsRequestPhase(Request.EcsRequestPhaseEnum.PRIMARY)
       .fulfillmentPreference(Request.FulfillmentPreferenceEnum.HOLD_SHELF)
       .pickupServicePointId(secondaryRequest.getPickupServicePointId());
+  }
+
+  private Request buildSecondaryRequest(EcsTlr ecsTlr) {
+    return requestsMapper.mapDtoToRequest(ecsTlr)
+      .ecsRequestPhase(Request.EcsRequestPhaseEnum.SECONDARY);
   }
 
   private static void updateEcsTlr(EcsTlr ecsTlr, RequestWrapper primaryRequest,

--- a/src/main/resources/swagger.api/schemas/request.json
+++ b/src/main/resources/swagger.api/schemas/request.json
@@ -19,6 +19,11 @@
       "type": "string",
       "enum": ["Item", "Title"]
     },
+    "ecsRequestPhase": {
+      "description": "Stage in ECS request process, absence of this field means this is a single-tenant request",
+      "type": "string",
+      "enum": ["Primary", "Secondary"]
+    },
     "requestDate": {
       "description": "Date the request was made",
       "type": "string",


### PR DESCRIPTION
## Purpose
Specify ECS request phase in primary and secondary requests.

## Approach
- add `ecsRequestPhase` to request schema
- specify phase when creating primary and secondary requests

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
