### PR TITLE
MODTLR-36: Upgrade packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17
 FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 # Copy your fat jar to the container provide the actual name for your fat jar file for example mod-notes-fat.jar
 ENV APP_FILE mod-tlr.jar


### PR DESCRIPTION
## Purpose
Run apk upgrade in the Dockerfile as recommended in
https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17#sample-module-dockerfile 
[MODTLR-36](https://folio-org.atlassian.net/browse/MODTLR-36)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
