### PR TITLE
[MODTLR-50] Use patronGroupId parameter instead of requesterId

### DIFF
--- a/src/main/java/org/folio/client/feign/CirculationClient.java
+++ b/src/main/java/org/folio/client/feign/CirculationClient.java
@@ -19,13 +19,13 @@ public interface CirculationClient {
 
   @GetMapping("/requests/allowed-service-points")
   AllowedServicePointsResponse allowedServicePointsWithStubItem(
-    @RequestParam("requesterId") String requesterId, @RequestParam("instanceId") String instanceId,
+    @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
     @RequestParam("operation") String operation, @RequestParam("useStubItem") boolean useStubItem);
 
 
   @GetMapping("/requests/allowed-service-points")
   AllowedServicePointsResponse allowedRoutingServicePoints(
-    @RequestParam("requesterId") String requesterId, @RequestParam("instanceId") String instanceId,
+    @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
     @RequestParam("operation") String operation,
     @RequestParam("ecsRequestRouting") boolean ecsRequestRouting);
 }

--- a/src/main/java/org/folio/controller/AllowedServicePointsController.java
+++ b/src/main/java/org/folio/controller/AllowedServicePointsController.java
@@ -27,35 +27,35 @@ public class AllowedServicePointsController implements AllowedServicePointsApi {
 
   @Override
   public ResponseEntity<AllowedServicePointsResponse> getAllowedServicePoints(String operation,
-    UUID requesterId, UUID instanceId, UUID requestId) {
+    UUID patronGroupId, UUID instanceId, UUID requestId) {
 
-    log.debug("getAllowedServicePoints:: params: operation={}, requesterId={}, instanceId={}, " +
-        "requestId={}", operation, requesterId, instanceId, requestId);
+    log.debug("getAllowedServicePoints:: params: operation={}, patronGroupId={}, instanceId={}, " +
+        "requestId={}", operation, patronGroupId, instanceId, requestId);
 
     RequestOperation requestOperation = Optional.ofNullable(operation)
       .map(String::toUpperCase)
       .map(RequestOperation::valueOf)
       .orElse(null);
 
-    if (validateAllowedServicePointsRequest(requestOperation, requesterId, instanceId, requestId)) {
+    if (validateAllowedServicePointsRequest(requestOperation, patronGroupId, instanceId, requestId)) {
       return ResponseEntity.status(OK).body(allowedServicePointsService.getAllowedServicePoints(
-        requestOperation, requesterId.toString(), instanceId.toString()));
+        requestOperation, patronGroupId.toString(), instanceId.toString()));
     } else {
       return ResponseEntity.status(UNPROCESSABLE_ENTITY).build();
     }
   }
 
   private static boolean validateAllowedServicePointsRequest(RequestOperation operation,
-    UUID requesterId, UUID instanceId, UUID requestId) {
+    UUID patronGroupId, UUID instanceId, UUID requestId) {
 
     log.debug("validateAllowedServicePointsRequest:: parameters operation: {}, requesterId: {}, " +
-      "instanceId: {}, requestId: {}", operation, requesterId, instanceId, requestId);
+      "instanceId: {}, requestId: {}", operation, patronGroupId, instanceId, requestId);
 
     boolean allowedCombinationOfParametersDetected = false;
 
     List<String> errors = new ArrayList<>();
 
-    if (operation == RequestOperation.CREATE && requesterId != null && instanceId != null &&
+    if (operation == RequestOperation.CREATE && patronGroupId != null && instanceId != null &&
       requestId == null) {
 
       log.info("validateAllowedServicePointsRequest:: TLR request creation case");

--- a/src/main/resources/swagger.api/allowed-service-points.yaml
+++ b/src/main/resources/swagger.api/allowed-service-points.yaml
@@ -11,7 +11,7 @@ paths:
       operationId: getAllowedServicePoints
       parameters:
         - $ref: '#/components/parameters/operation'
-        - $ref: '#/components/parameters/requesterId'
+        - $ref: '#/components/parameters/patronGroupId'
         - $ref: '#/components/parameters/instanceId'
         - $ref: '#/components/parameters/requestId'
       tags:
@@ -41,8 +41,8 @@ components:
         enum:
           - create
           - replace
-    requesterId:
-      name: requesterId
+    patronGroupId:
+      name: patronGroupId
       in: query
       required: true
       schema:

--- a/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
+++ b/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
@@ -85,11 +85,11 @@ class AllowedServicePointsApiTest extends BaseIT {
         .withHeader(TENANT_HEADER, equalTo(TENANT_ID_COLLEGE))
         .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege), HttpStatus.SC_OK)));
 
-    String requesterId = randomId();
+    String patronGroupId = randomId();
     String instanceId = randomId();
     doGet(
-      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&instanceId=%s",
-        requesterId, instanceId))
+      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&patronGroupId=%s&instanceId=%s",
+        patronGroupId, instanceId))
       .expectStatus().isEqualTo(200)
       .expectBody().json("{}");
 
@@ -100,13 +100,13 @@ class AllowedServicePointsApiTest extends BaseIT {
         HttpStatus.SC_OK)));
 
     doGet(
-      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&instanceId=%s",
-        requesterId, instanceId))
+      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&patronGroupId=%s&instanceId=%s",
+        patronGroupId, instanceId))
       .expectStatus().isEqualTo(200)
       .expectBody().json(asJsonString(allowedSpResponseConsortium));
 
     wireMockServer.verify(getRequestedFor(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL))
-      .withQueryParam("requesterId", equalTo(requesterId))
+      .withQueryParam("patronGroupId", equalTo(patronGroupId))
       .withQueryParam("instanceId", equalTo(instanceId))
       .withQueryParam("operation", equalTo("create"))
       .withQueryParam("useStubItem", equalTo("true")));
@@ -114,7 +114,7 @@ class AllowedServicePointsApiTest extends BaseIT {
 
   @Test
   void allowedServicePointsShouldReturn422WhenParametersAreInvalid() {
-    doGet(ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s", randomId()))
+    doGet(ALLOWED_SERVICE_POINTS_URL + format("?operation=create&patronGroupId=%s", randomId()))
       .expectStatus().isEqualTo(422);
   }
 


### PR DESCRIPTION
Covers: [MODTLR-50](https://folio-org.atlassian.net/browse/MODTLR-50)

## Purpose
Use patronGroupId parameter instead of requesterId