### PR TITLE
MODTLR-51: Create DCB transactions immediately when ECS TLR is created

### DIFF
--- a/src/main/java/org/folio/domain/mapper/EcsTlrMapper.java
+++ b/src/main/java/org/folio/domain/mapper/EcsTlrMapper.java
@@ -11,9 +11,9 @@ import org.mapstruct.NullValueCheckStrategy;
 @Mapper(componentModel = "spring", nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
 public interface EcsTlrMapper {
 
-  @Mapping(target = "requestType", qualifiedByName = "StringToRequestType")
-  @Mapping(target = "requestLevel", qualifiedByName = "StringToRequestLevel")
-  @Mapping(target = "fulfillmentPreference", qualifiedByName = "StringToFulfillmentPreference")
+  @Mapping(target = "requestType", qualifiedByName = "StringToEcsTlrRequestType")
+  @Mapping(target = "requestLevel", qualifiedByName = "StringToEcsTlrRequestLevel")
+  @Mapping(target = "fulfillmentPreference", qualifiedByName = "StringToEcsTlrFulfillmentPreference")
   EcsTlr mapEntityToDto(EcsTlrEntity ecsTlrEntity);
 
   @Mapping(target = "requestType", qualifiedByName = "RequestTypeToString")
@@ -21,19 +21,39 @@ public interface EcsTlrMapper {
   @Mapping(target = "fulfillmentPreference", qualifiedByName = "FulfillmentPreferenceToString")
   EcsTlrEntity mapDtoToEntity(EcsTlr ecsTlr);
 
-  @Named("StringToRequestType")
-  default EcsTlr.RequestTypeEnum mapRequestType(String requestType) {
+  @Mapping(target = "requestType", qualifiedByName = "StringToRequestType")
+  @Mapping(target = "requestLevel", qualifiedByName = "StringToRequestLevel")
+  @Mapping(target = "fulfillmentPreference", qualifiedByName = "StringToFulfillmentPreference")
+  Request mapEntityToRequest(EcsTlrEntity ecsTlr);
+
+  @Named("StringToEcsTlrRequestType")
+  default EcsTlr.RequestTypeEnum mapDtoRequestType(String requestType) {
     return requestType != null ? EcsTlr.RequestTypeEnum.fromValue(requestType) : null;
   }
 
-  @Named("StringToRequestLevel")
-  default EcsTlr.RequestLevelEnum mapRequestLevel(String requestLevel) {
+  @Named("StringToRequestType")
+  default Request.RequestTypeEnum mapRequestType(String requestType) {
+    return requestType != null ? Request.RequestTypeEnum.fromValue(requestType) : null;
+  }
+
+  @Named("StringToEcsTlrRequestLevel")
+  default EcsTlr.RequestLevelEnum mapDtoRequestLevel(String requestLevel) {
     return requestLevel != null ? EcsTlr.RequestLevelEnum.fromValue(requestLevel) : null;
   }
 
-  @Named("StringToFulfillmentPreference")
-  default EcsTlr.FulfillmentPreferenceEnum mapFulfillmentPreference(String fulfillmentPreference) {
+  @Named("StringToRequestLevel")
+  default Request.RequestLevelEnum mapRequestLevel(String requestLevel) {
+    return requestLevel != null ? Request.RequestLevelEnum.fromValue(requestLevel) : null;
+  }
+
+  @Named("StringToEcsTlrFulfillmentPreference")
+  default EcsTlr.FulfillmentPreferenceEnum mapDtoFulfillmentPreference(String fulfillmentPreference) {
     return fulfillmentPreference != null ? EcsTlr.FulfillmentPreferenceEnum.fromValue(fulfillmentPreference) : null;
+  }
+
+  @Named("StringToFulfillmentPreference")
+  default Request.FulfillmentPreferenceEnum mapFulfillmentPreference(String fulfillmentPreference) {
+    return fulfillmentPreference != null ? Request.FulfillmentPreferenceEnum.fromValue(fulfillmentPreference) : null;
   }
 
   @Named("RequestTypeToString")
@@ -51,5 +71,4 @@ public interface EcsTlrMapper {
     return fulfillmentPreferenceEnum != null ? fulfillmentPreferenceEnum.getValue() : null;
   }
 
-  Request mapDtoToRequest(EcsTlr ecsTlr);
 }

--- a/src/main/java/org/folio/service/DcbService.java
+++ b/src/main/java/org/folio/service/DcbService.java
@@ -9,7 +9,7 @@ import org.folio.domain.entity.EcsTlrEntity;
 
 public interface DcbService {
   void createLendingTransaction(EcsTlrEntity ecsTlr);
-  void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request primaryRequest);
+  void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request request);
   TransactionStatusResponse getTransactionStatus(UUID transactionId, String tenantId);
   TransactionStatusResponse updateTransactionStatus(UUID transactionId,
     TransactionStatus.StatusEnum newStatus, String tenantId);

--- a/src/main/java/org/folio/service/DcbService.java
+++ b/src/main/java/org/folio/service/DcbService.java
@@ -9,7 +9,7 @@ import org.folio.domain.entity.EcsTlrEntity;
 
 public interface DcbService {
   void createLendingTransaction(EcsTlrEntity ecsTlr);
-  void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request updatedRequest);
+  void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request primaryRequest);
   TransactionStatusResponse getTransactionStatus(UUID transactionId, String tenantId);
   TransactionStatusResponse updateTransactionStatus(UUID transactionId,
     TransactionStatus.StatusEnum newStatus, String tenantId);

--- a/src/main/java/org/folio/service/TenantService.java
+++ b/src/main/java/org/folio/service/TenantService.java
@@ -3,10 +3,10 @@ package org.folio.service;
 import java.util.List;
 import java.util.Optional;
 
-import org.folio.domain.dto.EcsTlr;
+import org.folio.domain.entity.EcsTlrEntity;
 
 public interface TenantService {
-  Optional<String> getBorrowingTenant(EcsTlr ecsTlr);
+  Optional<String> getBorrowingTenant(EcsTlrEntity ecsTlr);
 
-  List<String> getLendingTenants(EcsTlr ecsTlr);
+  List<String> getLendingTenants(EcsTlrEntity ecsTlr);
 }

--- a/src/main/java/org/folio/service/impl/DcbServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/DcbServiceImpl.java
@@ -50,12 +50,12 @@ public class DcbServiceImpl implements DcbService {
   }
 
   @Override
-  public void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request primaryRequest) {
+  public void createBorrowingTransaction(EcsTlrEntity ecsTlr, Request request) {
     log.info("createBorrowingTransaction:: creating borrowing transaction for ECS TLR {}", ecsTlr::getId);
     DcbItem dcbItem = new DcbItem()
-      .id(primaryRequest.getItemId())
-      .title(primaryRequest.getInstance().getTitle())
-      .barcode(primaryRequest.getItem().getBarcode());
+      .id(request.getItemId())
+      .title(request.getInstance().getTitle())
+      .barcode(request.getItem().getBarcode());
     DcbTransaction transaction = new DcbTransaction()
       .requestId(ecsTlr.getSecondaryRequestId().toString())
       .item(dcbItem)

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -137,7 +137,11 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     ecsTlr.setSecondaryRequestTenantId(secondaryRequest.tenantId());
     ecsTlr.setPrimaryRequestId(UUID.fromString(primaryRequest.request().getId()));
     ecsTlr.setSecondaryRequestId(UUID.fromString(secondaryRequest.request().getId()));
-    ecsTlr.setItemId(UUID.fromString(secondaryRequest.request().getItemId()));
+
+    Optional.of(secondaryRequest.request())
+      .map(Request::getItemId)
+      .map(UUID::fromString)
+      .ifPresent(ecsTlr::setItemId);
 
     log.info("updateEcsTlr:: ECS TLR updated in memory");
     log.debug("updateEcsTlr:: ECS TLR: {}", () -> ecsTlr);

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -53,7 +53,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     RequestWrapper primaryRequest = requestService.createPrimaryRequest(
       buildPrimaryRequest(secondaryRequest.request()), borrowingTenantId);
     updateEcsTlr(ecsTlr, primaryRequest, secondaryRequest);
-    createDcbTransactions(ecsTlr, primaryRequest.request());
+    createDcbTransactions(ecsTlr, secondaryRequest.request());
 
     return requestsMapper.mapEntityToDto(save(ecsTlr));
   }
@@ -143,12 +143,16 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     log.debug("updateEcsTlr:: ECS TLR: {}", () -> ecsTlr);
   }
 
-  private void createDcbTransactions(EcsTlrEntity ecsTlr, Request primaryRequest) {
+  private void createDcbTransactions(EcsTlrEntity ecsTlr, Request secondaryRequest) {
     if (ecsTlr.getItemId() == null) {
       log.info("createDcbTransactions:: ECS TLR has no item ID");
       return;
     }
-    dcbService.createBorrowingTransaction(ecsTlr, primaryRequest);
+    if (secondaryRequest.getItemId() == null) {
+      log.info("createDcbTransactions:: secondary request has no item ID");
+      return;
+    }
+    dcbService.createBorrowingTransaction(ecsTlr, secondaryRequest);
     dcbService.createLendingTransaction(ecsTlr);
   }
 

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -115,7 +115,6 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     return new Request()
       .id(secondaryRequest.getId())
       .instanceId(secondaryRequest.getInstanceId())
-      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
       .itemId(secondaryRequest.getItemId())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -144,10 +144,6 @@ public class EcsTlrServiceImpl implements EcsTlrService {
   }
 
   private void createDcbTransactions(EcsTlrEntity ecsTlr, Request secondaryRequest) {
-    if (ecsTlr.getItemId() == null) {
-      log.info("createDcbTransactions:: ECS TLR has no item ID");
-      return;
-    }
     if (secondaryRequest.getItemId() == null) {
       log.info("createDcbTransactions:: secondary request has no item ID");
       return;

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -115,6 +115,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     return new Request()
       .id(secondaryRequest.getId())
       .instanceId(secondaryRequest.getInstanceId())
+      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
       .itemId(secondaryRequest.getItemId())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -115,7 +115,6 @@ public class EcsTlrServiceImpl implements EcsTlrService {
     return new Request()
       .id(secondaryRequest.getId())
       .instanceId(secondaryRequest.getInstanceId())
-      .itemId(secondaryRequest.getItemId())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)

--- a/src/main/java/org/folio/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/TenantServiceImpl.java
@@ -24,11 +24,11 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.folio.client.feign.SearchClient;
-import org.folio.domain.dto.EcsTlr;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
 import org.folio.domain.dto.ItemStatusEnum;
+import org.folio.domain.entity.EcsTlrEntity;
 import org.folio.service.TenantService;
 import org.folio.util.HttpUtils;
 import org.jetbrains.annotations.NotNull;
@@ -44,14 +44,14 @@ public class TenantServiceImpl implements TenantService {
   private final SearchClient searchClient;
 
   @Override
-  public Optional<String> getBorrowingTenant(EcsTlr ecsTlr) {
+  public Optional<String> getBorrowingTenant(EcsTlrEntity ecsTlr) {
     log.info("getBorrowingTenant:: getting borrowing tenant");
     return HttpUtils.getTenantFromToken();
   }
 
   @Override
-  public List<String> getLendingTenants(EcsTlr ecsTlr) {
-    final String instanceId = ecsTlr.getInstanceId();
+  public List<String> getLendingTenants(EcsTlrEntity ecsTlr) {
+    final String instanceId = ecsTlr.getInstanceId().toString();
     log.info("getLendingTenants:: looking for potential lending tenants for instance {}", instanceId);
     var itemStatusOccurrencesByTenant = getItemStatusOccurrencesByTenant(instanceId);
     log.info("getLendingTenants:: item status occurrences by tenant: {}", itemStatusOccurrencesByTenant);

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -48,6 +48,7 @@ class EcsTlrApiTest extends BaseIT {
     "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
   private static final String TLR_URL = "/tlr/ecs-tlr";
   private static final String ITEM_ID = randomId();
+  private static final String HOLDINGS_ID = randomId();
   private static final String INSTANCE_ID = randomId();
   private static final String ECS_TLR_ID = randomId();
   private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
@@ -163,6 +164,7 @@ class EcsTlrApiTest extends BaseIT {
     Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
     Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
       .itemId(ITEM_ID)
+      .holdingsRecordId(HOLDINGS_ID)
       .item(new RequestItem().barcode(ITEM_BARCODE))
       .instance(new RequestInstance().title(INSTANCE_TITLE));
 
@@ -410,6 +412,7 @@ class EcsTlrApiTest extends BaseIT {
     return new Request()
       .id(PRIMARY_REQUEST_ID)
       .instanceId(secondaryRequest.getInstanceId())
+      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
       .itemId(secondaryRequest.getItemId())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -211,9 +211,9 @@ class EcsTlrApiTest extends BaseIT {
     // 2. Create ECS TLR
 
     EcsTlr expectedPostEcsTlrResponse = fromJsonString(asJsonString(ecsTlr), EcsTlr.class)
-      .primaryRequestId(primaryRequestPostRequest.getId())
+      .primaryRequestId(PRIMARY_REQUEST_ID)
       .primaryRequestTenantId(TENANT_ID_CONSORTIUM)
-      .secondaryRequestId(secondaryRequestPostRequest.getId())
+      .secondaryRequestId(SECONDARY_REQUEST_ID)
       .secondaryRequestTenantId(TENANT_ID_COLLEGE)
       .itemId(ITEM_ID);
 

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -48,6 +48,7 @@ class EcsTlrApiTest extends BaseIT {
     "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
   private static final String TLR_URL = "/tlr/ecs-tlr";
   private static final String ITEM_ID = randomId();
+  private static final String HOLDINGS_RECORD_ID = randomId();
   private static final String INSTANCE_ID = randomId();
   private static final String ECS_TLR_ID = randomId();
   private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
@@ -163,13 +164,12 @@ class EcsTlrApiTest extends BaseIT {
     Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
     Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
       .itemId(ITEM_ID)
+      .holdingsRecordId(HOLDINGS_RECORD_ID)
       .item(new RequestItem().barcode(ITEM_BARCODE))
       .instance(new RequestInstance().title(INSTANCE_TITLE));
 
-    Request primaryRequestPostRequest = buildPrimaryRequest(mockPostSecondaryRequestResponse);
-    Request mockPostPrimaryRequestResponse = buildPrimaryRequest(mockPostSecondaryRequestResponse)
-      .item(mockPostSecondaryRequestResponse.getItem())
-      .instance(mockPostSecondaryRequestResponse.getInstance());
+    Request primaryRequestPostRequest = buildPrimaryRequest(secondaryRequestPostRequest);
+    Request mockPostPrimaryRequestResponse = buildPrimaryRequest(mockPostSecondaryRequestResponse);
 
     wireMockServer.stubFor(post(urlMatching(INSTANCE_REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
@@ -409,8 +409,11 @@ class EcsTlrApiTest extends BaseIT {
   private static Request buildPrimaryRequest(Request secondaryRequest) {
     return new Request()
       .id(PRIMARY_REQUEST_ID)
-      .instanceId(secondaryRequest.getInstanceId())
       .itemId(secondaryRequest.getItemId())
+      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
+      .instanceId(secondaryRequest.getInstanceId())
+      .item(secondaryRequest.getItem())
+      .instance(secondaryRequest.getInstance())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -48,7 +48,6 @@ class EcsTlrApiTest extends BaseIT {
     "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
   private static final String TLR_URL = "/tlr/ecs-tlr";
   private static final String ITEM_ID = randomId();
-  private static final String HOLDINGS_ID = randomId();
   private static final String INSTANCE_ID = randomId();
   private static final String ECS_TLR_ID = randomId();
   private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
@@ -164,7 +163,6 @@ class EcsTlrApiTest extends BaseIT {
     Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
     Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
       .itemId(ITEM_ID)
-      .holdingsRecordId(HOLDINGS_ID)
       .item(new RequestItem().barcode(ITEM_BARCODE))
       .instance(new RequestInstance().title(INSTANCE_TITLE));
 
@@ -412,7 +410,6 @@ class EcsTlrApiTest extends BaseIT {
     return new Request()
       .id(PRIMARY_REQUEST_ID)
       .instanceId(secondaryRequest.getInstanceId())
-      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
       .itemId(secondaryRequest.getItemId())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -253,8 +253,7 @@ class EcsTlrApiTest extends BaseIT {
 
     if (secondaryRequestRequesterExists) {
       wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL)));
-      wireMockServer.verify(exactly(1),
-        putRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
+      wireMockServer.verify(exactly(1), putRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
     } else {
       wireMockServer.verify(postRequestedFor(urlMatching(USERS_URL))
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -12,6 +12,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.HOLD;
+import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.PAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -24,6 +26,7 @@ import org.apache.http.HttpStatus;
 import org.folio.domain.dto.DcbItem;
 import org.folio.domain.dto.DcbTransaction;
 import org.folio.domain.dto.EcsTlr;
+import org.folio.domain.dto.EcsTlr.RequestTypeEnum;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
@@ -44,19 +47,22 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 
 class EcsTlrApiTest extends BaseIT {
-  private static final String UUID_PATTERN =
-    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
-  private static final String TLR_URL = "/tlr/ecs-tlr";
   private static final String ITEM_ID = randomId();
   private static final String HOLDINGS_RECORD_ID = randomId();
   private static final String INSTANCE_ID = randomId();
-  private static final String ECS_TLR_ID = randomId();
-  private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
-  private static final String SECONDARY_REQUEST_ID = ECS_TLR_ID;
-  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
+  private static final String REQUESTER_ID = randomId();
+  private static final String PICKUP_SERVICE_POINT_ID = randomId();
   private static final String PATRON_GROUP_ID_SECONDARY = randomId();
   private static final String PATRON_GROUP_ID_PRIMARY = randomId();
   private static final String REQUESTER_BARCODE = randomId();
+  private static final String ECS_TLR_ID = randomId();
+  private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
+  private static final String SECONDARY_REQUEST_ID = ECS_TLR_ID;
+
+  private static final String UUID_PATTERN =
+    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
+  private static final String TLR_URL = "/tlr/ecs-tlr";
+  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
   private static final String REQUESTS_URL = "/circulation/requests";
   private static final String USERS_URL = "/users";
   private static final String SERVICE_POINTS_URL = "/service-points";
@@ -65,46 +71,61 @@ class EcsTlrApiTest extends BaseIT {
   private static final String ECS_REQUEST_TRANSACTIONS_URL = "/ecs-request-transactions";
   private static final String POST_ECS_REQUEST_TRANSACTION_URL_PATTERN =
     ECS_REQUEST_TRANSACTIONS_URL + "/" + UUID_PATTERN;
+
   private static final String INSTANCE_TITLE = "Test title";
   private static final String ITEM_BARCODE = "test_item_barcode";
+  private static final Date REQUEST_DATE = new Date();
+  private static final Date REQUEST_EXPIRATION_DATE = new Date();
+
+
 
   @BeforeEach
   public void beforeEach() {
     wireMockServer.resetAll();
   }
 
-  @Test
-  void getByIdNotFound() {
-    doGet(TLR_URL + "/" + UUID.randomUUID())
-      .expectStatus().isEqualTo(NOT_FOUND);
-  }
-
   @ParameterizedTest
   @CsvSource(value = {
-    "true, true",
-    "true, false",
-    "false, true",
-    "false, false"
+    "PAGE, true,  true",
+    "PAGE, true,  false",
+    "PAGE, false, true",
+    "PAGE, false, false",
+    "HOLD, true,  true",
+    "HOLD, true,  false",
+    "HOLD, false, true",
+    "HOLD, false, false",
+    "RECALL, true,  true",
+    "RECALL, true,  false",
+    "RECALL, false, true",
+    "RECALL, false, false"
   })
-  void ecsTlrIsCreated(boolean secondaryRequestRequesterExists,
+  void ecsTlrIsCreated(RequestTypeEnum requestType, boolean secondaryRequestRequesterExists,
     boolean secondaryRequestPickupServicePointExists) {
 
-    String requesterId = randomId();
-    String pickupServicePointId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
+    EcsTlr ecsTlr = buildEcsTlr(requestType);
 
     // 1. Create stubs for other modules
     // 1.1 Mock search endpoint
 
+    List<Item> items;
+    if (requestType == HOLD) {
+      items = List.of(
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Paged"),
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Declared lost"),
+        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Checked out"));
+    } else {
+      items = List.of(
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
+        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Available"));
+    }
+
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
-      .instances(List.of(
-        new Instance().id(INSTANCE_ID)
-          .tenantId(TENANT_ID_CONSORTIUM)
-          .items(List.of(
-            buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
-            buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
-            buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Available")))
+      .instances(List.of(new Instance()
+        .id(INSTANCE_ID)
+        .tenantId(TENANT_ID_CONSORTIUM)
+        .items(items)
       ));
 
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
@@ -112,11 +133,11 @@ class EcsTlrApiTest extends BaseIT {
 
     // 1.2 Mock user endpoints
 
-    User primaryRequestRequester = buildPrimaryRequestRequester(requesterId);
+    User primaryRequestRequester = buildPrimaryRequestRequester(REQUESTER_ID);
     User secondaryRequestRequester = buildSecondaryRequestRequester(primaryRequestRequester,
       secondaryRequestRequesterExists);
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_OK)));
 
@@ -124,7 +145,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(secondaryRequestRequester, HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequesterResponse));
 
@@ -132,18 +153,18 @@ class EcsTlrApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(secondaryRequestRequester, HttpStatus.SC_CREATED)));
 
-    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_NO_CONTENT)));
 
     // 1.3 Mock service point endpoints
 
     ServicePoint primaryRequestPickupServicePoint =
-      buildPrimaryRequestPickupServicePoint(pickupServicePointId);
+      buildPrimaryRequestPickupServicePoint(PICKUP_SERVICE_POINT_ID);
     ServicePoint secondaryRequestPickupServicePoint =
       buildSecondaryRequestPickupServicePoint(primaryRequestPickupServicePoint);
 
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(asJsonString(primaryRequestPickupServicePoint), HttpStatus.SC_OK)));
 
@@ -151,7 +172,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(asJsonString(secondaryRequestPickupServicePoint), HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequestPickupServicePointResponse));
 
@@ -162,11 +183,14 @@ class EcsTlrApiTest extends BaseIT {
     // 1.4 Mock request endpoints
 
     Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
-    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
-      .itemId(ITEM_ID)
-      .holdingsRecordId(HOLDINGS_RECORD_ID)
-      .item(new RequestItem().barcode(ITEM_BARCODE))
-      .instance(new RequestInstance().title(INSTANCE_TITLE));
+    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr);
+    if (requestType != HOLD) {
+      mockPostSecondaryRequestResponse
+        .itemId(ITEM_ID)
+        .holdingsRecordId(HOLDINGS_RECORD_ID)
+        .item(new RequestItem().barcode(ITEM_BARCODE))
+        .instance(new RequestInstance().title(INSTANCE_TITLE));
+    }
 
     Request primaryRequestPostRequest = buildPrimaryRequest(secondaryRequestPostRequest);
     Request mockPostPrimaryRequestResponse = buildPrimaryRequest(mockPostSecondaryRequestResponse);
@@ -210,37 +234,40 @@ class EcsTlrApiTest extends BaseIT {
 
     // 2. Create ECS TLR
 
-    EcsTlr expectedPostEcsTlrResponse = fromJsonString(asJsonString(ecsTlr), EcsTlr.class)
+    EcsTlr expectedPostEcsTlrResponse = buildEcsTlr(requestType)
       .primaryRequestId(PRIMARY_REQUEST_ID)
       .primaryRequestTenantId(TENANT_ID_CONSORTIUM)
       .secondaryRequestId(SECONDARY_REQUEST_ID)
       .secondaryRequestTenantId(TENANT_ID_COLLEGE)
-      .itemId(ITEM_ID);
+      .itemId(requestType == HOLD ? null : ITEM_ID);
 
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
-    doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
+    var response = doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
       .expectStatus().isCreated()
       .expectBody()
-      .json(asJsonString(expectedPostEcsTlrResponse))
-      .jsonPath("$.primaryRequestDcbTransactionId").exists()
-      .jsonPath("$.secondaryRequestDcbTransactionId").exists();
+      .json(asJsonString(expectedPostEcsTlrResponse));
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
+
+    if (requestType != HOLD) {
+      response.jsonPath("$.primaryRequestDcbTransactionId").exists()
+        .jsonPath("$.secondaryRequestDcbTransactionId").exists();
+    }
 
     // 3. Verify calls to other modules
 
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
     wireMockServer.verify(postRequestedFor(urlMatching(INSTANCE_REQUESTS_URL))
@@ -253,7 +280,7 @@ class EcsTlrApiTest extends BaseIT {
 
     if (secondaryRequestRequesterExists) {
       wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL)));
-      wireMockServer.verify(exactly(1), putRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
+      wireMockServer.verify(exactly(1), putRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID)));
     } else {
       wireMockServer.verify(postRequestedFor(urlMatching(USERS_URL))
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
@@ -268,18 +295,28 @@ class EcsTlrApiTest extends BaseIT {
         .withRequestBody(equalToJson(asJsonString(secondaryRequestPickupServicePoint))));
     }
 
-    wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest))));
+    if (requestType != HOLD) {
+      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+        .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest))));
 
-    wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest))));
+      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+        .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest))));
+    } else {
+      wireMockServer.verify(0, postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN)));
+    }
+  }
+
+  @Test
+  void getByIdNotFound() {
+    doGet(TLR_URL + "/" + UUID.randomUUID())
+      .expectStatus().isEqualTo(NOT_FOUND);
   }
 
   @Test
   void canNotCreateEcsTlrWhenFailedToExtractBorrowingTenantIdFromToken() {
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
     doPostWithToken(TLR_URL, ecsTlr, "not_a_token")
       .expectStatus().isEqualTo(500);
 
@@ -288,7 +325,7 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToPickLendingTenant() {
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(0)
       .instances(List.of());
@@ -308,7 +345,7 @@ class EcsTlrApiTest extends BaseIT {
   @Test
   void canNotCreateEcsTlrWhenFailedToFindRequesterInBorrowingTenant() {
     String requesterId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, requesterId, randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -338,9 +375,8 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToFindPickupServicePointInBorrowingTenant() {
-    String requesterId = randomId();
     String pickupServicePointId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, REQUESTER_ID, pickupServicePointId);
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -352,8 +388,8 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
       .willReturn(jsonResponse(mockSearchInstancesResponse, HttpStatus.SC_OK)));
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
-      .willReturn(jsonResponse(buildPrimaryRequestRequester(requesterId), HttpStatus.SC_OK)));
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+      .willReturn(jsonResponse(buildPrimaryRequestRequester(REQUESTER_ID), HttpStatus.SC_OK)));
 
     wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .willReturn(notFound()));
@@ -364,7 +400,7 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
     wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
@@ -374,20 +410,24 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(REQUESTS_URL)));
   }
 
-  private static EcsTlr buildEcsTlr(String instanceId, String requesterId,
+  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType) {
+    return buildEcsTlr(requestType, REQUESTER_ID, PICKUP_SERVICE_POINT_ID);
+  }
+
+  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType, String requesterId,
     String pickupServicePointId) {
 
     return new EcsTlr()
       .id(ECS_TLR_ID)
-      .instanceId(instanceId)
+      .instanceId(INSTANCE_ID)
       .requesterId(requesterId)
       .pickupServicePointId(pickupServicePointId)
       .requestLevel(EcsTlr.RequestLevelEnum.TITLE)
-      .requestType(EcsTlr.RequestTypeEnum.PAGE)
+      .requestType(requestType)
       .fulfillmentPreference(EcsTlr.FulfillmentPreferenceEnum.DELIVERY)
       .patronComments("random comment")
-      .requestDate(new Date())
-      .requestExpirationDate(new Date());
+      .requestDate(REQUEST_DATE)
+      .requestExpirationDate(REQUEST_EXPIRATION_DATE);
   }
 
   private static Request buildSecondaryRequest(EcsTlr ecsTlr) {

--- a/src/test/java/org/folio/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/service/TenantServiceTest.java
@@ -10,11 +10,11 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.folio.client.feign.SearchClient;
-import org.folio.domain.dto.EcsTlr;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
 import org.folio.domain.dto.SearchInstancesResponse;
+import org.folio.domain.entity.EcsTlrEntity;
 import org.folio.service.impl.TenantServiceImpl;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,7 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TenantServiceTest {
-  private static final String INSTANCE_ID = UUID.randomUUID().toString();
+  private static final UUID INSTANCE_ID = UUID.randomUUID();
 
   @Mock
   private SearchClient searchClient;
@@ -39,7 +39,9 @@ class TenantServiceTest {
   void getLendingTenants(List<String> expectedTenantIds, Instance instance) {
     Mockito.when(searchClient.searchInstance(Mockito.any()))
       .thenReturn(new SearchInstancesResponse().instances(singletonList(instance)));
-    assertEquals(expectedTenantIds, tenantService.getLendingTenants(new EcsTlr().instanceId(INSTANCE_ID)));
+    EcsTlrEntity ecsTlr = new EcsTlrEntity();
+    ecsTlr.setInstanceId(INSTANCE_ID);
+    assertEquals(expectedTenantIds, tenantService.getLendingTenants(ecsTlr));
   }
 
   private static Stream<Arguments> parametersForGetLendingTenants() {
@@ -132,7 +134,7 @@ class TenantServiceTest {
 
   private static Instance buildInstance(Item... items) {
     return new Instance()
-      .id(INSTANCE_ID)
+      .id(INSTANCE_ID.toString())
       .tenantId("centralTenant")
       .items(Arrays.stream(items).toList());
   }


### PR DESCRIPTION
## Purpose
Currently, DCB transactions are created upon secondary request update and only for TLR hold requests. They should also be created for all other request type and level combinations immediately when ECS TLR is created.
[MODTLR-51](https://folio-org.atlassian.net/browse/MODTLR-51)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
