### PR TITLE
MODTLR-52 switch additionalProperties to true to defined schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <!-- runtime dependencies -->
     <folio-spring-base.version>7.2.2</folio-spring-base.version>
     <folio-spring-system-user.version>7.2.2</folio-spring-system-user.version>
-    <openapi-generator.version>6.2.1</openapi-generator.version>
+    <openapi-generator.version>7.1.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
 
     <!-- test dependencies -->

--- a/src/main/resources/swagger.api/schemas/userGroup.json
+++ b/src/main/resources/swagger.api/schemas/userGroup.json
@@ -27,7 +27,7 @@
       "$ref": "metadata.json"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "group"
   ]

--- a/src/main/resources/swagger.api/schemas/userTenant.json
+++ b/src/main/resources/swagger.api/schemas/userTenant.json
@@ -48,7 +48,7 @@
       "$ref": "uuid.json"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "userId",
     "tenantId"

--- a/src/main/resources/swagger.api/schemas/userTenantCollection.json
+++ b/src/main/resources/swagger.api/schemas/userTenantCollection.json
@@ -16,7 +16,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "userTenants",
     "totalRecords"


### PR DESCRIPTION
## Purpose
Add additionalProperties: true to UserGroup, UserTenant, UserTenantCollection schemas. Some tests will fail.
## Approach
Updated openapi generator plugin version

[MODTLR-52](https://folio-org.atlassian.net/browse/MODTLR-52)