### PR TITLE
MODTLR-53 Autogenerate UUID for ECS TLR when client doesn't provide it

### DIFF
--- a/src/main/java/org/folio/domain/entity/EcsTlrEntity.java
+++ b/src/main/java/org/folio/domain/entity/EcsTlrEntity.java
@@ -1,5 +1,6 @@
 package org.folio.domain.entity;
 
+import jakarta.persistence.GeneratedValue;
 import java.util.Date;
 import java.util.UUID;
 
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 public class EcsTlrEntity {
 
   @Id
+  @GeneratedValue
   private UUID id;
   private UUID instanceId;
   private UUID requesterId;

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -126,6 +126,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
 
   private Request buildSecondaryRequest(EcsTlrEntity ecsTlr) {
     return requestsMapper.mapEntityToRequest(ecsTlr)
+      .id(UUID.randomUUID().toString())
       .ecsRequestPhase(Request.EcsRequestPhaseEnum.SECONDARY);
   }
 

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -126,7 +126,6 @@ public class EcsTlrServiceImpl implements EcsTlrService {
 
   private Request buildSecondaryRequest(EcsTlrEntity ecsTlr) {
     return requestsMapper.mapEntityToRequest(ecsTlr)
-      .id(UUID.randomUUID().toString())
       .ecsRequestPhase(Request.EcsRequestPhaseEnum.SECONDARY);
   }
 

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -183,7 +183,8 @@ class EcsTlrApiTest extends BaseIT {
     // 1.4 Mock request endpoints
 
     Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
-    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr);
+    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr).id(SECONDARY_REQUEST_ID);
+
     if (requestType != HOLD) {
       mockPostSecondaryRequestResponse
         .itemId(ITEM_ID)
@@ -247,6 +248,8 @@ class EcsTlrApiTest extends BaseIT {
       .expectBody()
       .json(asJsonString(expectedPostEcsTlrResponse));
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
+
+    response.jsonPath("$.id").exists();
 
     if (requestType != HOLD) {
       response.jsonPath("$.primaryRequestDcbTransactionId").exists()
@@ -431,7 +434,6 @@ class EcsTlrApiTest extends BaseIT {
 
   private static Request buildSecondaryRequest(EcsTlr ecsTlr) {
     return new Request()
-      .id(SECONDARY_REQUEST_ID)
       .requesterId(ecsTlr.getRequesterId())
       .requestLevel(Request.RequestLevelEnum.fromValue(ecsTlr.getRequestLevel().getValue()))
       .requestType(Request.RequestTypeEnum.fromValue(ecsTlr.getRequestType().getValue()))

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -55,9 +55,8 @@ class EcsTlrApiTest extends BaseIT {
   private static final String PATRON_GROUP_ID_SECONDARY = randomId();
   private static final String PATRON_GROUP_ID_PRIMARY = randomId();
   private static final String REQUESTER_BARCODE = randomId();
-  private static final String ECS_TLR_ID = randomId();
-  private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
-  private static final String SECONDARY_REQUEST_ID = ECS_TLR_ID;
+  private static final String SECONDARY_REQUEST_ID = randomId();
+  private static final String PRIMARY_REQUEST_ID = SECONDARY_REQUEST_ID;
 
   private static final String UUID_PATTERN =
     "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
@@ -246,10 +245,9 @@ class EcsTlrApiTest extends BaseIT {
     var response = doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
       .expectStatus().isCreated()
       .expectBody()
+      .jsonPath("$.id").exists()
       .json(asJsonString(expectedPostEcsTlrResponse));
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
-
-    response.jsonPath("$.id").exists();
 
     if (requestType != HOLD) {
       response.jsonPath("$.primaryRequestDcbTransactionId").exists()

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -12,6 +12,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.HOLD;
+import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.PAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -21,13 +23,19 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.http.HttpStatus;
+import org.folio.domain.dto.DcbItem;
+import org.folio.domain.dto.DcbTransaction;
 import org.folio.domain.dto.EcsTlr;
+import org.folio.domain.dto.EcsTlr.RequestTypeEnum;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
 import org.folio.domain.dto.Request;
+import org.folio.domain.dto.RequestInstance;
+import org.folio.domain.dto.RequestItem;
 import org.folio.domain.dto.SearchInstancesResponse;
 import org.folio.domain.dto.ServicePoint;
+import org.folio.domain.dto.TransactionStatusResponse;
 import org.folio.domain.dto.User;
 import org.folio.domain.dto.UserPersonal;
 import org.folio.domain.dto.UserType;
@@ -39,76 +47,97 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 
 class EcsTlrApiTest extends BaseIT {
-  private static final String TLR_URL = "/tlr/ecs-tlr";
+  private static final String ITEM_ID = randomId();
+  private static final String HOLDINGS_RECORD_ID = randomId();
   private static final String INSTANCE_ID = randomId();
-  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
+  private static final String REQUESTER_ID = randomId();
+  private static final String PICKUP_SERVICE_POINT_ID = randomId();
   private static final String PATRON_GROUP_ID_SECONDARY = randomId();
   private static final String PATRON_GROUP_ID_PRIMARY = randomId();
   private static final String REQUESTER_BARCODE = randomId();
+  private static final String ECS_TLR_ID = randomId();
+  private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
+  private static final String SECONDARY_REQUEST_ID = ECS_TLR_ID;
+
+  private static final String UUID_PATTERN =
+    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
+  private static final String TLR_URL = "/tlr/ecs-tlr";
+  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
   private static final String REQUESTS_URL = "/circulation/requests";
   private static final String USERS_URL = "/users";
   private static final String SERVICE_POINTS_URL = "/service-points";
   private static final String SEARCH_INSTANCES_URL =
     "/search/instances\\?query=id==" + INSTANCE_ID + "&expandAll=true";
+  private static final String ECS_REQUEST_TRANSACTIONS_URL = "/ecs-request-transactions";
+  private static final String POST_ECS_REQUEST_TRANSACTION_URL_PATTERN =
+    ECS_REQUEST_TRANSACTIONS_URL + "/" + UUID_PATTERN;
+
+  private static final String INSTANCE_TITLE = "Test title";
+  private static final String ITEM_BARCODE = "test_item_barcode";
+  private static final Date REQUEST_DATE = new Date();
+  private static final Date REQUEST_EXPIRATION_DATE = new Date();
+
+
 
   @BeforeEach
   public void beforeEach() {
     wireMockServer.resetAll();
   }
 
-  @Test
-  void getByIdNotFound() {
-    doGet(TLR_URL + "/" + UUID.randomUUID())
-      .expectStatus().isEqualTo(NOT_FOUND);
-  }
-
   @ParameterizedTest
   @CsvSource(value = {
-    "true, true",
-    "true, false",
-    "false, true",
-    "false, false"
+    "PAGE, true,  true",
+    "PAGE, true,  false",
+    "PAGE, false, true",
+    "PAGE, false, false",
+    "HOLD, true,  true",
+    "HOLD, true,  false",
+    "HOLD, false, true",
+    "HOLD, false, false",
+    "RECALL, true,  true",
+    "RECALL, true,  false",
+    "RECALL, false, true",
+    "RECALL, false, false"
   })
-  void ecsTlrIsCreated(boolean secondaryRequestRequesterExists,
+  void ecsTlrIsCreated(RequestTypeEnum requestType, boolean secondaryRequestRequesterExists,
     boolean secondaryRequestPickupServicePointExists) {
 
-    String availableItemId = randomId();
-    String requesterId = randomId();
-    String pickupServicePointId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
+    EcsTlr ecsTlr = buildEcsTlr(requestType);
 
-    // 1. Create mock responses from other modules
+    // 1. Create stubs for other modules
+    // 1.1 Mock search endpoint
+
+    List<Item> items;
+    if (requestType == HOLD) {
+      items = List.of(
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Paged"),
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Declared lost"),
+        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Checked out"));
+    } else {
+      items = List.of(
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
+        buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
+        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Available"));
+    }
 
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
-      .instances(List.of(
-        new Instance().id(INSTANCE_ID)
-          .tenantId(TENANT_ID_CONSORTIUM)
-          .items(List.of(
-            buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
-            buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
-            buildItem(availableItemId, TENANT_ID_COLLEGE, "Available")))
+      .instances(List.of(new Instance()
+        .id(INSTANCE_ID)
+        .tenantId(TENANT_ID_CONSORTIUM)
+        .items(items)
       ));
-
-    Request secondaryRequest = buildSecondaryRequest(ecsTlr);
-    Request primaryRequest = buildPrimaryRequest(secondaryRequest);
-    User primaryRequestRequester = buildPrimaryRequestRequester(requesterId);
-    User secondaryRequestRequester = buildSecondaryRequestRequester(primaryRequestRequester,
-      secondaryRequestRequesterExists);
-    ServicePoint primaryRequestPickupServicePoint =
-      buildPrimaryRequestPickupServicePoint(pickupServicePointId);
-    ServicePoint secondaryRequestPickupServicePoint =
-      buildSecondaryRequestPickupServicePoint(primaryRequestPickupServicePoint);
-
-    // 2. Create stubs for other modules
-    // 2.1 Mock search endpoint
 
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
       .willReturn(jsonResponse(mockSearchInstancesResponse, HttpStatus.SC_OK)));
 
-    // 2.2 Mock user endpoints
+    // 1.2 Mock user endpoints
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
+    User primaryRequestRequester = buildPrimaryRequestRequester(REQUESTER_ID);
+    User secondaryRequestRequester = buildSecondaryRequestRequester(primaryRequestRequester,
+      secondaryRequestRequesterExists);
+
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_OK)));
 
@@ -116,7 +145,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(secondaryRequestRequester, HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequesterResponse));
 
@@ -124,13 +153,18 @@ class EcsTlrApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(secondaryRequestRequester, HttpStatus.SC_CREATED)));
 
-    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_NO_CONTENT)));
 
-    // 2.3 Mock service point endpoints
+    // 1.3 Mock service point endpoints
 
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    ServicePoint primaryRequestPickupServicePoint =
+      buildPrimaryRequestPickupServicePoint(PICKUP_SERVICE_POINT_ID);
+    ServicePoint secondaryRequestPickupServicePoint =
+      buildSecondaryRequestPickupServicePoint(primaryRequestPickupServicePoint);
+
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(asJsonString(primaryRequestPickupServicePoint), HttpStatus.SC_OK)));
 
@@ -138,7 +172,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(asJsonString(secondaryRequestPickupServicePoint), HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequestPickupServicePointResponse));
 
@@ -146,62 +180,107 @@ class EcsTlrApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(asJsonString(secondaryRequestPickupServicePoint), HttpStatus.SC_CREATED)));
 
-    // 2.4 Mock request endpoints
+    // 1.4 Mock request endpoints
 
-    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
-      .itemId(availableItemId);
+    Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
+    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr);
+    if (requestType != HOLD) {
+      mockPostSecondaryRequestResponse
+        .itemId(ITEM_ID)
+        .holdingsRecordId(HOLDINGS_RECORD_ID)
+        .item(new RequestItem().barcode(ITEM_BARCODE))
+        .instance(new RequestInstance().title(INSTANCE_TITLE));
+    }
+
+    Request primaryRequestPostRequest = buildPrimaryRequest(secondaryRequestPostRequest);
+    Request mockPostPrimaryRequestResponse = buildPrimaryRequest(mockPostSecondaryRequestResponse);
 
     wireMockServer.stubFor(post(urlMatching(INSTANCE_REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .withRequestBody(equalToJson(asJsonString(secondaryRequestPostRequest)))
       .willReturn(jsonResponse(asJsonString(mockPostSecondaryRequestResponse), HttpStatus.SC_CREATED)));
 
     wireMockServer.stubFor(post(urlMatching(REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(primaryRequest), HttpStatus.SC_CREATED)));
+      .withRequestBody(equalToJson(asJsonString(primaryRequestPostRequest)))
+      .willReturn(jsonResponse(asJsonString(mockPostPrimaryRequestResponse), HttpStatus.SC_CREATED)));
 
-    // 3. Create ECS TLR
+    // 1.5 Mock DCB endpoints
 
-    EcsTlr expectedPostEcsTlrResponse = fromJsonString(asJsonString(ecsTlr), EcsTlr.class)
-      .primaryRequestId(primaryRequest.getId())
+    DcbTransaction borrowerTransactionPostRequest = new DcbTransaction()
+      .role(DcbTransaction.RoleEnum.BORROWER)
+      .item(new DcbItem()
+        .id(ITEM_ID)
+        .barcode(ITEM_BARCODE)
+        .title(INSTANCE_TITLE))
+      .requestId(PRIMARY_REQUEST_ID);
+
+    DcbTransaction lenderTransactionPostRequest = new DcbTransaction()
+      .role(DcbTransaction.RoleEnum.LENDER)
+      .requestId(SECONDARY_REQUEST_ID);
+
+    TransactionStatusResponse mockPostEcsDcbTransactionResponse = new TransactionStatusResponse()
+      .status(TransactionStatusResponse.StatusEnum.CREATED);
+
+    wireMockServer.stubFor(post(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest)))
+      .willReturn(jsonResponse(mockPostEcsDcbTransactionResponse, HttpStatus.SC_CREATED)));
+
+    wireMockServer.stubFor(post(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest)))
+      .willReturn(jsonResponse(mockPostEcsDcbTransactionResponse, HttpStatus.SC_CREATED)));
+
+    // 2. Create ECS TLR
+
+    EcsTlr expectedPostEcsTlrResponse = buildEcsTlr(requestType)
+      .primaryRequestId(PRIMARY_REQUEST_ID)
       .primaryRequestTenantId(TENANT_ID_CONSORTIUM)
-      .secondaryRequestId(secondaryRequest.getId())
+      .secondaryRequestId(SECONDARY_REQUEST_ID)
       .secondaryRequestTenantId(TENANT_ID_COLLEGE)
-      .itemId(availableItemId);
+      .itemId(requestType == HOLD ? null : ITEM_ID);
 
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
-    doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
+    var response = doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
       .expectStatus().isCreated()
-      .expectBody().json(asJsonString(expectedPostEcsTlrResponse));
+      .expectBody()
+      .json(asJsonString(expectedPostEcsTlrResponse));
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
 
-    // 4. Verify calls to other modules
+    if (requestType != HOLD) {
+      response.jsonPath("$.primaryRequestDcbTransactionId").exists()
+        .jsonPath("$.secondaryRequestDcbTransactionId").exists();
+    }
+
+    // 3. Verify calls to other modules
+
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
     wireMockServer.verify(postRequestedFor(urlMatching(INSTANCE_REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)) // because this tenant has available item
-      .withRequestBody(equalToJson(asJsonString(secondaryRequest))));
+      .withRequestBody(equalToJson(asJsonString(secondaryRequestPostRequest))));
 
     wireMockServer.verify(postRequestedFor(urlMatching(REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(primaryRequest))));
+      .withRequestBody(equalToJson(asJsonString(primaryRequestPostRequest))));
 
     if (secondaryRequestRequesterExists) {
       wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL)));
-      wireMockServer.verify(exactly(1),
-        putRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
+      wireMockServer.verify(exactly(1), putRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID)));
     } else {
       wireMockServer.verify(postRequestedFor(urlMatching(USERS_URL))
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
@@ -215,11 +294,29 @@ class EcsTlrApiTest extends BaseIT {
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
         .withRequestBody(equalToJson(asJsonString(secondaryRequestPickupServicePoint))));
     }
+
+    if (requestType != HOLD) {
+      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+        .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest))));
+
+      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
+        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+        .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest))));
+    } else {
+      wireMockServer.verify(0, postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN)));
+    }
+  }
+
+  @Test
+  void getByIdNotFound() {
+    doGet(TLR_URL + "/" + UUID.randomUUID())
+      .expectStatus().isEqualTo(NOT_FOUND);
   }
 
   @Test
   void canNotCreateEcsTlrWhenFailedToExtractBorrowingTenantIdFromToken() {
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
     doPostWithToken(TLR_URL, ecsTlr, "not_a_token")
       .expectStatus().isEqualTo(500);
 
@@ -228,7 +325,7 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToPickLendingTenant() {
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(0)
       .instances(List.of());
@@ -248,7 +345,7 @@ class EcsTlrApiTest extends BaseIT {
   @Test
   void canNotCreateEcsTlrWhenFailedToFindRequesterInBorrowingTenant() {
     String requesterId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, randomId());
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, requesterId, randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -278,9 +375,8 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToFindPickupServicePointInBorrowingTenant() {
-    String requesterId = randomId();
     String pickupServicePointId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
+    EcsTlr ecsTlr = buildEcsTlr(PAGE, REQUESTER_ID, pickupServicePointId);
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -292,8 +388,8 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
       .willReturn(jsonResponse(mockSearchInstancesResponse, HttpStatus.SC_OK)));
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
-      .willReturn(jsonResponse(buildPrimaryRequestRequester(requesterId), HttpStatus.SC_OK)));
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+      .willReturn(jsonResponse(buildPrimaryRequestRequester(REQUESTER_ID), HttpStatus.SC_OK)));
 
     wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .willReturn(notFound()));
@@ -304,7 +400,7 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
     wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
@@ -314,30 +410,33 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(REQUESTS_URL)));
   }
 
-  private static EcsTlr buildEcsTlr(String instanceId, String requesterId,
+  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType) {
+    return buildEcsTlr(requestType, REQUESTER_ID, PICKUP_SERVICE_POINT_ID);
+  }
+
+  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType, String requesterId,
     String pickupServicePointId) {
 
     return new EcsTlr()
-      .instanceId(instanceId)
+      .instanceId(INSTANCE_ID)
       .requesterId(requesterId)
       .pickupServicePointId(pickupServicePointId)
       .requestLevel(EcsTlr.RequestLevelEnum.TITLE)
-      .requestType(EcsTlr.RequestTypeEnum.PAGE)
+      .requestType(requestType)
       .fulfillmentPreference(EcsTlr.FulfillmentPreferenceEnum.DELIVERY)
       .patronComments("random comment")
-      .requestDate(new Date())
-      .requestExpirationDate(new Date());
+      .requestDate(REQUEST_DATE)
+      .requestExpirationDate(REQUEST_EXPIRATION_DATE);
   }
 
   private static Request buildSecondaryRequest(EcsTlr ecsTlr) {
     return new Request()
-      .id(ecsTlr.getId())
+      .id(SECONDARY_REQUEST_ID)
       .requesterId(ecsTlr.getRequesterId())
       .requestLevel(Request.RequestLevelEnum.fromValue(ecsTlr.getRequestLevel().getValue()))
       .requestType(Request.RequestTypeEnum.fromValue(ecsTlr.getRequestType().getValue()))
       .ecsRequestPhase(Request.EcsRequestPhaseEnum.SECONDARY)
       .instanceId(ecsTlr.getInstanceId())
-      .itemId(ecsTlr.getItemId())
       .pickupServicePointId(ecsTlr.getPickupServicePointId())
       .requestDate(ecsTlr.getRequestDate())
       .requestExpirationDate(ecsTlr.getRequestExpirationDate())
@@ -347,8 +446,12 @@ class EcsTlrApiTest extends BaseIT {
 
   private static Request buildPrimaryRequest(Request secondaryRequest) {
     return new Request()
-      .id(secondaryRequest.getId())
+      .id(PRIMARY_REQUEST_ID)
+      .itemId(secondaryRequest.getItemId())
+      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
       .instanceId(secondaryRequest.getInstanceId())
+      .item(secondaryRequest.getItem())
+      .instance(secondaryRequest.getInstance())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -12,8 +12,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.HOLD;
-import static org.folio.domain.dto.EcsTlr.RequestTypeEnum.PAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -23,19 +21,13 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.http.HttpStatus;
-import org.folio.domain.dto.DcbItem;
-import org.folio.domain.dto.DcbTransaction;
 import org.folio.domain.dto.EcsTlr;
-import org.folio.domain.dto.EcsTlr.RequestTypeEnum;
 import org.folio.domain.dto.Instance;
 import org.folio.domain.dto.Item;
 import org.folio.domain.dto.ItemStatus;
 import org.folio.domain.dto.Request;
-import org.folio.domain.dto.RequestInstance;
-import org.folio.domain.dto.RequestItem;
 import org.folio.domain.dto.SearchInstancesResponse;
 import org.folio.domain.dto.ServicePoint;
-import org.folio.domain.dto.TransactionStatusResponse;
 import org.folio.domain.dto.User;
 import org.folio.domain.dto.UserPersonal;
 import org.folio.domain.dto.UserType;
@@ -47,97 +39,76 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 
 class EcsTlrApiTest extends BaseIT {
-  private static final String ITEM_ID = randomId();
-  private static final String HOLDINGS_RECORD_ID = randomId();
+  private static final String TLR_URL = "/tlr/ecs-tlr";
   private static final String INSTANCE_ID = randomId();
-  private static final String REQUESTER_ID = randomId();
-  private static final String PICKUP_SERVICE_POINT_ID = randomId();
+  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
   private static final String PATRON_GROUP_ID_SECONDARY = randomId();
   private static final String PATRON_GROUP_ID_PRIMARY = randomId();
   private static final String REQUESTER_BARCODE = randomId();
-  private static final String ECS_TLR_ID = randomId();
-  private static final String PRIMARY_REQUEST_ID = ECS_TLR_ID;
-  private static final String SECONDARY_REQUEST_ID = ECS_TLR_ID;
-
-  private static final String UUID_PATTERN =
-    "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
-  private static final String TLR_URL = "/tlr/ecs-tlr";
-  private static final String INSTANCE_REQUESTS_URL = "/circulation/requests/instances";
   private static final String REQUESTS_URL = "/circulation/requests";
   private static final String USERS_URL = "/users";
   private static final String SERVICE_POINTS_URL = "/service-points";
   private static final String SEARCH_INSTANCES_URL =
     "/search/instances\\?query=id==" + INSTANCE_ID + "&expandAll=true";
-  private static final String ECS_REQUEST_TRANSACTIONS_URL = "/ecs-request-transactions";
-  private static final String POST_ECS_REQUEST_TRANSACTION_URL_PATTERN =
-    ECS_REQUEST_TRANSACTIONS_URL + "/" + UUID_PATTERN;
-
-  private static final String INSTANCE_TITLE = "Test title";
-  private static final String ITEM_BARCODE = "test_item_barcode";
-  private static final Date REQUEST_DATE = new Date();
-  private static final Date REQUEST_EXPIRATION_DATE = new Date();
-
-
 
   @BeforeEach
   public void beforeEach() {
     wireMockServer.resetAll();
   }
 
+  @Test
+  void getByIdNotFound() {
+    doGet(TLR_URL + "/" + UUID.randomUUID())
+      .expectStatus().isEqualTo(NOT_FOUND);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
-    "PAGE, true,  true",
-    "PAGE, true,  false",
-    "PAGE, false, true",
-    "PAGE, false, false",
-    "HOLD, true,  true",
-    "HOLD, true,  false",
-    "HOLD, false, true",
-    "HOLD, false, false",
-    "RECALL, true,  true",
-    "RECALL, true,  false",
-    "RECALL, false, true",
-    "RECALL, false, false"
+    "true, true",
+    "true, false",
+    "false, true",
+    "false, false"
   })
-  void ecsTlrIsCreated(RequestTypeEnum requestType, boolean secondaryRequestRequesterExists,
+  void ecsTlrIsCreated(boolean secondaryRequestRequesterExists,
     boolean secondaryRequestPickupServicePointExists) {
 
-    EcsTlr ecsTlr = buildEcsTlr(requestType);
+    String availableItemId = randomId();
+    String requesterId = randomId();
+    String pickupServicePointId = randomId();
+    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
 
-    // 1. Create stubs for other modules
-    // 1.1 Mock search endpoint
-
-    List<Item> items;
-    if (requestType == HOLD) {
-      items = List.of(
-        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Paged"),
-        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Declared lost"),
-        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Checked out"));
-    } else {
-      items = List.of(
-        buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
-        buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
-        buildItem(ITEM_ID, TENANT_ID_COLLEGE, "Available"));
-    }
+    // 1. Create mock responses from other modules
 
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
-      .instances(List.of(new Instance()
-        .id(INSTANCE_ID)
-        .tenantId(TENANT_ID_CONSORTIUM)
-        .items(items)
+      .instances(List.of(
+        new Instance().id(INSTANCE_ID)
+          .tenantId(TENANT_ID_CONSORTIUM)
+          .items(List.of(
+            buildItem(randomId(), TENANT_ID_UNIVERSITY, "Checked out"),
+            buildItem(randomId(), TENANT_ID_UNIVERSITY, "In transit"),
+            buildItem(availableItemId, TENANT_ID_COLLEGE, "Available")))
       ));
+
+    Request secondaryRequest = buildSecondaryRequest(ecsTlr);
+    Request primaryRequest = buildPrimaryRequest(secondaryRequest);
+    User primaryRequestRequester = buildPrimaryRequestRequester(requesterId);
+    User secondaryRequestRequester = buildSecondaryRequestRequester(primaryRequestRequester,
+      secondaryRequestRequesterExists);
+    ServicePoint primaryRequestPickupServicePoint =
+      buildPrimaryRequestPickupServicePoint(pickupServicePointId);
+    ServicePoint secondaryRequestPickupServicePoint =
+      buildSecondaryRequestPickupServicePoint(primaryRequestPickupServicePoint);
+
+    // 2. Create stubs for other modules
+    // 2.1 Mock search endpoint
 
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
       .willReturn(jsonResponse(mockSearchInstancesResponse, HttpStatus.SC_OK)));
 
-    // 1.2 Mock user endpoints
+    // 2.2 Mock user endpoints
 
-    User primaryRequestRequester = buildPrimaryRequestRequester(REQUESTER_ID);
-    User secondaryRequestRequester = buildSecondaryRequestRequester(primaryRequestRequester,
-      secondaryRequestRequesterExists);
-
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_OK)));
 
@@ -145,7 +116,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(secondaryRequestRequester, HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequesterResponse));
 
@@ -153,18 +124,13 @@ class EcsTlrApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(secondaryRequestRequester, HttpStatus.SC_CREATED)));
 
-    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.stubFor(put(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(primaryRequestRequester, HttpStatus.SC_NO_CONTENT)));
 
-    // 1.3 Mock service point endpoints
+    // 2.3 Mock service point endpoints
 
-    ServicePoint primaryRequestPickupServicePoint =
-      buildPrimaryRequestPickupServicePoint(PICKUP_SERVICE_POINT_ID);
-    ServicePoint secondaryRequestPickupServicePoint =
-      buildSecondaryRequestPickupServicePoint(primaryRequestPickupServicePoint);
-
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(asJsonString(primaryRequestPickupServicePoint), HttpStatus.SC_OK)));
 
@@ -172,7 +138,7 @@ class EcsTlrApiTest extends BaseIT {
       ? jsonResponse(asJsonString(secondaryRequestPickupServicePoint), HttpStatus.SC_OK)
       : notFound();
 
-    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
+    wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(mockGetSecondaryRequestPickupServicePointResponse));
 
@@ -180,107 +146,62 @@ class EcsTlrApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(asJsonString(secondaryRequestPickupServicePoint), HttpStatus.SC_CREATED)));
 
-    // 1.4 Mock request endpoints
+    // 2.4 Mock request endpoints
 
-    Request secondaryRequestPostRequest = buildSecondaryRequest(ecsTlr);
-    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr);
-    if (requestType != HOLD) {
-      mockPostSecondaryRequestResponse
-        .itemId(ITEM_ID)
-        .holdingsRecordId(HOLDINGS_RECORD_ID)
-        .item(new RequestItem().barcode(ITEM_BARCODE))
-        .instance(new RequestInstance().title(INSTANCE_TITLE));
-    }
-
-    Request primaryRequestPostRequest = buildPrimaryRequest(secondaryRequestPostRequest);
-    Request mockPostPrimaryRequestResponse = buildPrimaryRequest(mockPostSecondaryRequestResponse);
+    Request mockPostSecondaryRequestResponse = buildSecondaryRequest(ecsTlr)
+      .itemId(availableItemId);
 
     wireMockServer.stubFor(post(urlMatching(INSTANCE_REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .withRequestBody(equalToJson(asJsonString(secondaryRequestPostRequest)))
       .willReturn(jsonResponse(asJsonString(mockPostSecondaryRequestResponse), HttpStatus.SC_CREATED)));
 
     wireMockServer.stubFor(post(urlMatching(REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(primaryRequestPostRequest)))
-      .willReturn(jsonResponse(asJsonString(mockPostPrimaryRequestResponse), HttpStatus.SC_CREATED)));
+      .willReturn(jsonResponse(asJsonString(primaryRequest), HttpStatus.SC_CREATED)));
 
-    // 1.5 Mock DCB endpoints
+    // 3. Create ECS TLR
 
-    DcbTransaction borrowerTransactionPostRequest = new DcbTransaction()
-      .role(DcbTransaction.RoleEnum.BORROWER)
-      .item(new DcbItem()
-        .id(ITEM_ID)
-        .barcode(ITEM_BARCODE)
-        .title(INSTANCE_TITLE))
-      .requestId(PRIMARY_REQUEST_ID);
-
-    DcbTransaction lenderTransactionPostRequest = new DcbTransaction()
-      .role(DcbTransaction.RoleEnum.LENDER)
-      .requestId(SECONDARY_REQUEST_ID);
-
-    TransactionStatusResponse mockPostEcsDcbTransactionResponse = new TransactionStatusResponse()
-      .status(TransactionStatusResponse.StatusEnum.CREATED);
-
-    wireMockServer.stubFor(post(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest)))
-      .willReturn(jsonResponse(mockPostEcsDcbTransactionResponse, HttpStatus.SC_CREATED)));
-
-    wireMockServer.stubFor(post(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest)))
-      .willReturn(jsonResponse(mockPostEcsDcbTransactionResponse, HttpStatus.SC_CREATED)));
-
-    // 2. Create ECS TLR
-
-    EcsTlr expectedPostEcsTlrResponse = buildEcsTlr(requestType)
-      .primaryRequestId(PRIMARY_REQUEST_ID)
+    EcsTlr expectedPostEcsTlrResponse = fromJsonString(asJsonString(ecsTlr), EcsTlr.class)
+      .primaryRequestId(primaryRequest.getId())
       .primaryRequestTenantId(TENANT_ID_CONSORTIUM)
-      .secondaryRequestId(SECONDARY_REQUEST_ID)
+      .secondaryRequestId(secondaryRequest.getId())
       .secondaryRequestTenantId(TENANT_ID_COLLEGE)
-      .itemId(requestType == HOLD ? null : ITEM_ID);
+      .itemId(availableItemId);
 
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
-    var response = doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
+    doPostWithTenant(TLR_URL, ecsTlr, TENANT_ID_CONSORTIUM)
       .expectStatus().isCreated()
-      .expectBody()
-      .json(asJsonString(expectedPostEcsTlrResponse));
+      .expectBody().json(asJsonString(expectedPostEcsTlrResponse));
     assertEquals(TENANT_ID_CONSORTIUM, getCurrentTenantId());
 
-    if (requestType != HOLD) {
-      response.jsonPath("$.primaryRequestDcbTransactionId").exists()
-        .jsonPath("$.secondaryRequestDcbTransactionId").exists();
-    }
-
-    // 3. Verify calls to other modules
-
+    // 4. Verify calls to other modules
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + PICKUP_SERVICE_POINT_ID))
+    wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
     wireMockServer.verify(postRequestedFor(urlMatching(INSTANCE_REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)) // because this tenant has available item
-      .withRequestBody(equalToJson(asJsonString(secondaryRequestPostRequest))));
+      .withRequestBody(equalToJson(asJsonString(secondaryRequest))));
 
     wireMockServer.verify(postRequestedFor(urlMatching(REQUESTS_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(primaryRequestPostRequest))));
+      .withRequestBody(equalToJson(asJsonString(primaryRequest))));
 
     if (secondaryRequestRequesterExists) {
       wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(USERS_URL)));
-      wireMockServer.verify(exactly(1), putRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID)));
+      wireMockServer.verify(exactly(1),
+        putRequestedFor(urlMatching(USERS_URL + "/" + requesterId)));
     } else {
       wireMockServer.verify(postRequestedFor(urlMatching(USERS_URL))
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
@@ -294,29 +215,11 @@ class EcsTlrApiTest extends BaseIT {
         .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
         .withRequestBody(equalToJson(asJsonString(secondaryRequestPickupServicePoint))));
     }
-
-    if (requestType != HOLD) {
-      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-        .withRequestBody(equalToJson(asJsonString(borrowerTransactionPostRequest))));
-
-      wireMockServer.verify(postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN))
-        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-        .withRequestBody(equalToJson(asJsonString(lenderTransactionPostRequest))));
-    } else {
-      wireMockServer.verify(0, postRequestedFor(urlMatching(POST_ECS_REQUEST_TRANSACTION_URL_PATTERN)));
-    }
-  }
-
-  @Test
-  void getByIdNotFound() {
-    doGet(TLR_URL + "/" + UUID.randomUUID())
-      .expectStatus().isEqualTo(NOT_FOUND);
   }
 
   @Test
   void canNotCreateEcsTlrWhenFailedToExtractBorrowingTenantIdFromToken() {
-    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
     doPostWithToken(TLR_URL, ecsTlr, "not_a_token")
       .expectStatus().isEqualTo(500);
 
@@ -325,7 +228,7 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToPickLendingTenant() {
-    EcsTlr ecsTlr = buildEcsTlr(PAGE, randomId(), randomId());
+    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, randomId(), randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(0)
       .instances(List.of());
@@ -345,7 +248,7 @@ class EcsTlrApiTest extends BaseIT {
   @Test
   void canNotCreateEcsTlrWhenFailedToFindRequesterInBorrowingTenant() {
     String requesterId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(PAGE, requesterId, randomId());
+    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, randomId());
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -375,8 +278,9 @@ class EcsTlrApiTest extends BaseIT {
 
   @Test
   void canNotCreateEcsTlrWhenFailedToFindPickupServicePointInBorrowingTenant() {
+    String requesterId = randomId();
     String pickupServicePointId = randomId();
-    EcsTlr ecsTlr = buildEcsTlr(PAGE, REQUESTER_ID, pickupServicePointId);
+    EcsTlr ecsTlr = buildEcsTlr(INSTANCE_ID, requesterId, pickupServicePointId);
     SearchInstancesResponse mockSearchInstancesResponse = new SearchInstancesResponse()
       .totalRecords(2)
       .instances(List.of(
@@ -388,8 +292,8 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
       .willReturn(jsonResponse(mockSearchInstancesResponse, HttpStatus.SC_OK)));
 
-    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + REQUESTER_ID))
-      .willReturn(jsonResponse(buildPrimaryRequestRequester(REQUESTER_ID), HttpStatus.SC_OK)));
+    wireMockServer.stubFor(get(urlMatching(USERS_URL + "/" + requesterId))
+      .willReturn(jsonResponse(buildPrimaryRequestRequester(requesterId), HttpStatus.SC_OK)));
 
     wireMockServer.stubFor(get(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
       .willReturn(notFound()));
@@ -400,7 +304,7 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(getRequestedFor(urlMatching(SEARCH_INSTANCES_URL))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + REQUESTER_ID))
+    wireMockServer.verify(getRequestedFor(urlMatching(USERS_URL + "/" + requesterId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
     wireMockServer.verify(getRequestedFor(urlMatching(SERVICE_POINTS_URL + "/" + pickupServicePointId))
@@ -410,34 +314,30 @@ class EcsTlrApiTest extends BaseIT {
     wireMockServer.verify(exactly(0), postRequestedFor(urlMatching(REQUESTS_URL)));
   }
 
-  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType) {
-    return buildEcsTlr(requestType, REQUESTER_ID, PICKUP_SERVICE_POINT_ID);
-  }
-
-  private static EcsTlr buildEcsTlr(RequestTypeEnum requestType, String requesterId,
+  private static EcsTlr buildEcsTlr(String instanceId, String requesterId,
     String pickupServicePointId) {
 
     return new EcsTlr()
-      .id(ECS_TLR_ID)
-      .instanceId(INSTANCE_ID)
+      .instanceId(instanceId)
       .requesterId(requesterId)
       .pickupServicePointId(pickupServicePointId)
       .requestLevel(EcsTlr.RequestLevelEnum.TITLE)
-      .requestType(requestType)
+      .requestType(EcsTlr.RequestTypeEnum.PAGE)
       .fulfillmentPreference(EcsTlr.FulfillmentPreferenceEnum.DELIVERY)
       .patronComments("random comment")
-      .requestDate(REQUEST_DATE)
-      .requestExpirationDate(REQUEST_EXPIRATION_DATE);
+      .requestDate(new Date())
+      .requestExpirationDate(new Date());
   }
 
   private static Request buildSecondaryRequest(EcsTlr ecsTlr) {
     return new Request()
-      .id(SECONDARY_REQUEST_ID)
+      .id(ecsTlr.getId())
       .requesterId(ecsTlr.getRequesterId())
       .requestLevel(Request.RequestLevelEnum.fromValue(ecsTlr.getRequestLevel().getValue()))
       .requestType(Request.RequestTypeEnum.fromValue(ecsTlr.getRequestType().getValue()))
       .ecsRequestPhase(Request.EcsRequestPhaseEnum.SECONDARY)
       .instanceId(ecsTlr.getInstanceId())
+      .itemId(ecsTlr.getItemId())
       .pickupServicePointId(ecsTlr.getPickupServicePointId())
       .requestDate(ecsTlr.getRequestDate())
       .requestExpirationDate(ecsTlr.getRequestExpirationDate())
@@ -447,12 +347,8 @@ class EcsTlrApiTest extends BaseIT {
 
   private static Request buildPrimaryRequest(Request secondaryRequest) {
     return new Request()
-      .id(PRIMARY_REQUEST_ID)
-      .itemId(secondaryRequest.getItemId())
-      .holdingsRecordId(secondaryRequest.getHoldingsRecordId())
+      .id(secondaryRequest.getId())
       .instanceId(secondaryRequest.getInstanceId())
-      .item(secondaryRequest.getItem())
-      .instance(secondaryRequest.getInstance())
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)

--- a/src/test/java/org/folio/controller/KafkaEventListenerTest.java
+++ b/src/test/java/org/folio/controller/KafkaEventListenerTest.java
@@ -123,7 +123,7 @@ class KafkaEventListenerTest extends BaseIT {
     KafkaEvent<Request> event = buildSecondaryRequestUpdateEvent(oldRequestStatus, newRequestStatus);
     publishEventAndWait(SECONDARY_REQUEST_TENANT_ID, REQUEST_KAFKA_TOPIC_NAME, event);
 
-    EcsTlrEntity updatedEcsTlr = getEcsTlr(ECS_TLR_ID);
+    EcsTlrEntity updatedEcsTlr = getEcsTlr(initialEcsTlr.getId());
     assertEquals(ITEM_ID, updatedEcsTlr.getItemId());
 
     UUID secondaryRequestTransactionId = updatedEcsTlr.getSecondaryRequestDcbTransactionId();
@@ -153,7 +153,7 @@ class KafkaEventListenerTest extends BaseIT {
     KafkaEvent<Request> event = buildSecondaryRequestUpdateEvent(oldRequestStatus, newRequestStatus);
     publishEventAndWait(SECONDARY_REQUEST_TENANT_ID, REQUEST_KAFKA_TOPIC_NAME, event);
 
-    EcsTlrEntity updatedEcsTlr = getEcsTlr(ECS_TLR_ID);
+    EcsTlrEntity updatedEcsTlr = getEcsTlr(initialEcsTlr.getId());
     UUID transactionId = updatedEcsTlr.getSecondaryRequestDcbTransactionId();
     verifyThatNoDcbTransactionsWereCreated();
     verifyThatDcbTransactionStatusWasRetrieved(transactionId, SECONDARY_REQUEST_TENANT_ID);
@@ -208,7 +208,7 @@ class KafkaEventListenerTest extends BaseIT {
     KafkaEvent<Request> event = buildPrimaryRequestUpdateEvent(oldRequestStatus, newRequestStatus);
     publishEventAndWait(PRIMARY_REQUEST_TENANT_ID, REQUEST_KAFKA_TOPIC_NAME, event);
 
-    EcsTlrEntity updatedEcsTlr = getEcsTlr(ECS_TLR_ID);
+    EcsTlrEntity updatedEcsTlr = getEcsTlr(initialEcsTlr.getId());
     UUID transactionId = updatedEcsTlr.getPrimaryRequestDcbTransactionId();
     verifyThatNoDcbTransactionsWereCreated();
     verifyThatDcbTransactionStatusWasRetrieved(transactionId, PRIMARY_REQUEST_TENANT_ID);
@@ -251,7 +251,7 @@ class KafkaEventListenerTest extends BaseIT {
     KafkaEvent<Request> event = buildPrimaryRequestUpdateEvent(OPEN_NOT_YET_FILLED, OPEN_IN_TRANSIT);
     publishEventAndWait(PRIMARY_REQUEST_TENANT_ID, REQUEST_KAFKA_TOPIC_NAME, event);
 
-    EcsTlrEntity updatedEcsTlr = getEcsTlr(ECS_TLR_ID);
+    EcsTlrEntity updatedEcsTlr = getEcsTlr(initialEcsTlr.getId());
     UUID transactionId = updatedEcsTlr.getPrimaryRequestDcbTransactionId();
     verifyThatNoDcbTransactionsWereCreated();
     verifyThatDcbTransactionStatusWasRetrieved(transactionId, PRIMARY_REQUEST_TENANT_ID);
@@ -753,7 +753,6 @@ class KafkaEventListenerTest extends BaseIT {
 
   private static EcsTlrEntity buildEcsTlrWithItemId() {
     return EcsTlrEntity.builder()
-      .id(ECS_TLR_ID)
       .primaryRequestId(PRIMARY_REQUEST_ID)
       .primaryRequestTenantId(PRIMARY_REQUEST_TENANT_ID)
       .primaryRequestDcbTransactionId(PRIMARY_REQUEST_DCB_TRANSACTION_ID)
@@ -767,7 +766,6 @@ class KafkaEventListenerTest extends BaseIT {
 
   private static EcsTlrEntity buildEcsTlrWithoutItemId() {
     return EcsTlrEntity.builder()
-      .id(ECS_TLR_ID)
       .primaryRequestId(PRIMARY_REQUEST_ID)
       .primaryRequestTenantId(PRIMARY_REQUEST_TENANT_ID)
       .secondaryRequestId(SECONDARY_REQUEST_ID)


### PR DESCRIPTION
## Purpose
When ECS TLR POST request comes without an id, mod-tlr needs to generate one

[MODTLR-53](https://folio-org.atlassian.net/browse/MODTLR-53)