### PR TITLE
MODTLR-56: Support for operation `replace` in Allowed Service Points API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,7 +56,9 @@
             "circulation.requests.allowed-service-points.get",
             "users.item.get",
             "users.collection.get",
-            "search.instances.collection.get"
+            "search.instances.collection.get",
+            "circulation-storage.requests.item.get",
+            "circulation-storage.requests.collection.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/client/feign/CirculationClient.java
+++ b/src/main/java/org/folio/client/feign/CirculationClient.java
@@ -22,10 +22,20 @@ public interface CirculationClient {
     @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
     @RequestParam("operation") String operation, @RequestParam("useStubItem") boolean useStubItem);
 
+  @GetMapping("/requests/allowed-service-points")
+  AllowedServicePointsResponse allowedServicePointsWithStubItem(
+    @RequestParam("operation") String operation, @RequestParam("requestId") String requestId,
+    @RequestParam("useStubItem") boolean useStubItem);
+
 
   @GetMapping("/requests/allowed-service-points")
   AllowedServicePointsResponse allowedRoutingServicePoints(
     @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
     @RequestParam("operation") String operation,
+    @RequestParam("ecsRequestRouting") boolean ecsRequestRouting);
+
+  @GetMapping("/requests/allowed-service-points")
+  AllowedServicePointsResponse allowedRoutingServicePoints(
+    @RequestParam("operation") String operation, @RequestParam("requestId") String requestId,
     @RequestParam("ecsRequestRouting") boolean ecsRequestRouting);
 }

--- a/src/main/java/org/folio/controller/AllowedServicePointsController.java
+++ b/src/main/java/org/folio/controller/AllowedServicePointsController.java
@@ -1,13 +1,15 @@
 package org.folio.controller;
 
+import static org.folio.domain.dto.RequestOperation.CREATE;
+import static org.folio.domain.dto.RequestOperation.REPLACE;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
+import org.folio.domain.dto.AllowedServicePointsRequest;
 import org.folio.domain.dto.AllowedServicePointsResponse;
 import org.folio.domain.dto.RequestOperation;
 import org.folio.rest.resource.AllowedServicePointsApi;
@@ -29,36 +31,41 @@ public class AllowedServicePointsController implements AllowedServicePointsApi {
   public ResponseEntity<AllowedServicePointsResponse> getAllowedServicePoints(String operation,
     UUID requesterId, UUID instanceId, UUID requestId) {
 
-    log.debug("getAllowedServicePoints:: params: operation={}, requesterId={}, instanceId={}, " +
+    log.info("getAllowedServicePoints:: params: operation={}, requesterId={}, instanceId={}, " +
         "requestId={}", operation, requesterId, instanceId, requestId);
 
-    RequestOperation requestOperation = Optional.ofNullable(operation)
-      .map(String::toUpperCase)
-      .map(RequestOperation::valueOf)
-      .orElse(null);
+    AllowedServicePointsRequest request = new AllowedServicePointsRequest(
+      operation, requesterId, instanceId, requestId);
 
-    if (validateAllowedServicePointsRequest(requestOperation, requesterId, instanceId, requestId)) {
-      return ResponseEntity.status(OK).body(allowedServicePointsService.getAllowedServicePoints(
-        requestOperation, requesterId.toString(), instanceId.toString()));
+    if (validateAllowedServicePointsRequest(request)) {
+      return ResponseEntity.status(OK)
+        .body(allowedServicePointsService.getAllowedServicePoints(request));
     } else {
       return ResponseEntity.status(UNPROCESSABLE_ENTITY).build();
     }
   }
 
-  private static boolean validateAllowedServicePointsRequest(RequestOperation operation,
-    UUID requesterId, UUID instanceId, UUID requestId) {
-
-    log.debug("validateAllowedServicePointsRequest:: parameters operation: {}, requesterId: {}, " +
-      "instanceId: {}, requestId: {}", operation, requesterId, instanceId, requestId);
+  private static boolean validateAllowedServicePointsRequest(AllowedServicePointsRequest request) {
+    final RequestOperation operation = request.getOperation();
+    final String requesterId = request.getRequesterId();
+    final String instanceId = request.getInstanceId();
+    final String requestId = request.getRequestId();
 
     boolean allowedCombinationOfParametersDetected = false;
 
     List<String> errors = new ArrayList<>();
 
-    if (operation == RequestOperation.CREATE && requesterId != null && instanceId != null &&
+    if (operation == CREATE && requesterId != null && instanceId != null &&
       requestId == null) {
 
       log.info("validateAllowedServicePointsRequest:: TLR request creation case");
+      allowedCombinationOfParametersDetected = true;
+    }
+
+    if (operation == REPLACE && requesterId == null && instanceId == null &&
+      requestId != null) {
+
+      log.info("validateAllowedServicePointsRequest:: request replacement case");
       allowedCombinationOfParametersDetected = true;
     }
 

--- a/src/main/java/org/folio/domain/Constants.java
+++ b/src/main/java/org/folio/domain/Constants.java
@@ -1,0 +1,13 @@
+package org.folio.domain;
+
+import static org.folio.domain.dto.Request.RequestTypeEnum.HOLD;
+
+import org.folio.domain.dto.Request;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Constants {
+  public static final String CENTRAL_TENANT_ID = "consortium";
+  public static final Request.RequestTypeEnum PRIMARY_REQUEST_TYPE = HOLD;
+}

--- a/src/main/java/org/folio/domain/dto/AllowedServicePointsRequest.java
+++ b/src/main/java/org/folio/domain/dto/AllowedServicePointsRequest.java
@@ -18,12 +18,12 @@ public class AllowedServicePointsRequest {
     UUID requestId) {
 
     this.operation = RequestOperation.from(operation);
-    this.requesterId = toString(requesterId);
-    this.instanceId = toString(instanceId);
-    this.requestId = toString(requestId);
+    this.requesterId = asString(requesterId);
+    this.instanceId = asString(instanceId);
+    this.requestId = asString(requestId);
   }
 
-  private static String toString(UUID uuid) {
+  private static String asString(UUID uuid) {
     return Optional.ofNullable(uuid)
       .map(UUID::toString)
       .orElse(null);

--- a/src/main/java/org/folio/domain/dto/AllowedServicePointsRequest.java
+++ b/src/main/java/org/folio/domain/dto/AllowedServicePointsRequest.java
@@ -1,0 +1,32 @@
+package org.folio.domain.dto;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AllowedServicePointsRequest {
+  private final RequestOperation operation;
+  private final String requesterId;
+  private final String instanceId;
+  private final String requestId;
+
+  public AllowedServicePointsRequest(String operation, UUID requesterId, UUID instanceId,
+    UUID requestId) {
+
+    this.operation = RequestOperation.from(operation);
+    this.requesterId = toString(requesterId);
+    this.instanceId = toString(instanceId);
+    this.requestId = toString(requestId);
+  }
+
+  private static String toString(UUID uuid) {
+    return Optional.ofNullable(uuid)
+      .map(UUID::toString)
+      .orElse(null);
+  }
+
+}

--- a/src/main/java/org/folio/domain/dto/RequestOperation.java
+++ b/src/main/java/org/folio/domain/dto/RequestOperation.java
@@ -1,5 +1,22 @@
 package org.folio.domain.dto;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum RequestOperation {
-  CREATE, REPLACE;
+  CREATE("create"),
+  REPLACE("replace");
+
+  private final String value;
+
+  public static RequestOperation from(String operation) {
+    return valueOf(operation.toUpperCase());
+  }
+
+  @Override
+  public String toString() {
+    return getValue();
+  }
 }

--- a/src/main/java/org/folio/listener/kafka/KafkaEventListener.java
+++ b/src/main/java/org/folio/listener/kafka/KafkaEventListener.java
@@ -1,5 +1,7 @@
 package org.folio.listener.kafka;
 
+import static org.folio.domain.Constants.CENTRAL_TENANT_ID;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -29,7 +31,6 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class KafkaEventListener {
   private static final ObjectMapper objectMapper = new ObjectMapper();
-  public static final String CENTRAL_TENANT_ID = "consortium";
   private final RequestEventHandler requestEventHandler;
   private final UserGroupEventHandler userGroupEventHandler;
   private final SystemUserScopedExecutionService systemUserScopedExecutionService;

--- a/src/main/java/org/folio/repository/EcsTlrRepository.java
+++ b/src/main/java/org/folio/repository/EcsTlrRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EcsTlrRepository extends JpaRepository<EcsTlrEntity, UUID> {
   Optional<EcsTlrEntity> findBySecondaryRequestId(UUID secondaryRequestId);
+  Optional<EcsTlrEntity> findByPrimaryRequestId(UUID primaryRequestId);
   Optional<EcsTlrEntity> findByInstanceId(UUID instanceId);
   List<EcsTlrEntity> findByPrimaryRequestIdIn(List<UUID> primaryRequestIds);
 }

--- a/src/main/java/org/folio/service/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/service/AllowedServicePointsService.java
@@ -2,7 +2,6 @@ package org.folio.service;
 
 import org.folio.domain.dto.AllowedServicePointsRequest;
 import org.folio.domain.dto.AllowedServicePointsResponse;
-import org.folio.domain.dto.RequestOperation;
 
 public interface AllowedServicePointsService {
 

--- a/src/main/java/org/folio/service/AllowedServicePointsService.java
+++ b/src/main/java/org/folio/service/AllowedServicePointsService.java
@@ -1,9 +1,10 @@
 package org.folio.service;
 
+import org.folio.domain.dto.AllowedServicePointsRequest;
 import org.folio.domain.dto.AllowedServicePointsResponse;
 import org.folio.domain.dto.RequestOperation;
 
 public interface AllowedServicePointsService {
-  AllowedServicePointsResponse getAllowedServicePoints(RequestOperation operation,
-    String requesterId, String instanceId);
+
+  AllowedServicePointsResponse getAllowedServicePoints(AllowedServicePointsRequest request);
 }

--- a/src/main/java/org/folio/service/RequestService.java
+++ b/src/main/java/org/folio/service/RequestService.java
@@ -13,6 +13,7 @@ public interface RequestService {
     Collection<String> lendingTenantIds);
 
   Request getRequestFromStorage(String requestId, String tenantId);
+  Request getRequestFromStorage(String requestId);
   Request updateRequestInStorage(Request request, String tenantId);
   List<Request> getRequestsByInstanceId(String instanceId);
 }

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
@@ -100,7 +100,7 @@ public class AllowedServicePointsServiceImpl implements AllowedServicePointsServ
       return new AllowedServicePointsResponse();
     }
 
-    return getAllowedServicePointsFromBorrowingTenant(request, requestIsNotLinkedToItem);
+    return getAllowedServicePointsFromBorrowingTenant(request);
   }
 
   private EcsTlrEntity findEcsTlr(AllowedServicePointsRequest request) {
@@ -115,11 +115,11 @@ public class AllowedServicePointsServiceImpl implements AllowedServicePointsServ
   }
 
   private AllowedServicePointsResponse getAllowedServicePointsFromBorrowingTenant(
-    AllowedServicePointsRequest request, boolean useStubItem) {
+    AllowedServicePointsRequest request) {
 
     log.info("getForReplace:: fetching allowed service points from borrowing tenant");
     var allowedServicePoints = circulationClient.allowedServicePointsWithStubItem(
-      REPLACE.getValue(), request.getRequestId(), useStubItem);
+      REPLACE.getValue(), request.getRequestId(), true);
 
     Request.RequestTypeEnum primaryRequestType = Constants.PRIMARY_REQUEST_TYPE;
     log.info("getAllowedServicePointsFromBorrowingTenant:: primary request type: {}",

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
@@ -42,14 +42,12 @@ public class AllowedServicePointsServiceImpl implements AllowedServicePointsServ
   public AllowedServicePointsResponse getAllowedServicePoints(AllowedServicePointsRequest request) {
     log.info("getAllowedServicePoints:: {}", request);
     return switch (request.getOperation()) {
-      case CREATE -> getAllowedServicePointsForCreate(request);
-      case REPLACE -> getAllowedServicePointsForReplace(request);
+      case CREATE -> getForCreate(request);
+      case REPLACE -> getForReplace(request);
     };
   }
 
-  public AllowedServicePointsResponse getAllowedServicePointsForCreate(
-    AllowedServicePointsRequest request) {
-
+  public AllowedServicePointsResponse getForCreate(AllowedServicePointsRequest request) {
     String instanceId = request.getInstanceId();
     String patronGroupId = userService.find(request.getRequesterId()).getPatronGroup();
     log.info("getForCreate:: patronGroupId={}", patronGroupId);
@@ -92,9 +90,7 @@ public class AllowedServicePointsServiceImpl implements AllowedServicePointsServ
     return availabilityCheckResult;
   }
 
-  private AllowedServicePointsResponse getAllowedServicePointsForReplace(
-    AllowedServicePointsRequest request) {
-
+  private AllowedServicePointsResponse getForReplace(AllowedServicePointsRequest request) {
     EcsTlrEntity ecsTlr = findEcsTlr(request);
     final boolean requestIsLinkedToItem = ecsTlr.getItemId() != null;
     log.info("getForReplace:: request is linked to an item: {}", requestIsLinkedToItem);
@@ -109,10 +105,10 @@ public class AllowedServicePointsServiceImpl implements AllowedServicePointsServ
 
   private EcsTlrEntity findEcsTlr(AllowedServicePointsRequest request) {
     final String primaryRequestId = request.getRequestId();
-    log.info("findEcsTlr:: looking for ECS TLR with primary request ID {}", primaryRequestId);
+    log.info("findEcsTlr:: looking for ECS TLR with primary request {}", primaryRequestId);
     EcsTlrEntity ecsTlr = ecsTlrRepository.findByPrimaryRequestId(UUID.fromString(primaryRequestId))
       .orElseThrow(() -> new EntityNotFoundException(String.format(
-        "ECS TLR for primary request with ID %s was not found", primaryRequestId)));
+        "ECS TLR for primary request %s was not found", primaryRequestId)));
 
     log.info("findEcsTlr:: ECS TLR found: {}", ecsTlr.getId());
     return ecsTlr;

--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.folio.domain.Constants;
 import org.folio.domain.RequestWrapper;
 import org.folio.domain.dto.EcsTlr;
 import org.folio.domain.dto.Request;
@@ -118,7 +119,7 @@ public class EcsTlrServiceImpl implements EcsTlrService {
       .requesterId(secondaryRequest.getRequesterId())
       .requestDate(secondaryRequest.getRequestDate())
       .requestLevel(Request.RequestLevelEnum.TITLE)
-      .requestType(Request.RequestTypeEnum.HOLD)
+      .requestType(Constants.PRIMARY_REQUEST_TYPE)
       .ecsRequestPhase(Request.EcsRequestPhaseEnum.PRIMARY)
       .fulfillmentPreference(Request.FulfillmentPreferenceEnum.HOLD_SHELF)
       .pickupServicePointId(secondaryRequest.getPickupServicePointId());

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -104,8 +104,13 @@ public class RequestServiceImpl implements RequestService {
   @Override
   public Request getRequestFromStorage(String requestId, String tenantId) {
     log.info("getRequestFromStorage:: getting request {} from storage in tenant {}", requestId, tenantId);
-    return executionService.executeSystemUserScoped(tenantId,
-      () -> requestStorageClient.getRequest(requestId));
+    return executionService.executeSystemUserScoped(tenantId, () -> getRequestFromStorage(requestId));
+  }
+
+  @Override
+  public Request getRequestFromStorage(String requestId) {
+    log.info("getRequestFromStorage:: getting request {} from storage", requestId);
+    return requestStorageClient.getRequest(requestId);
   }
 
   @Override

--- a/src/main/resources/swagger.api/allowed-service-points.yaml
+++ b/src/main/resources/swagger.api/allowed-service-points.yaml
@@ -44,7 +44,7 @@ components:
     requesterId:
       name: requesterId
       in: query
-      required: true
+      required: false
       schema:
         type: string
         format: uuid

--- a/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
+++ b/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
@@ -157,7 +157,7 @@ class AllowedServicePointsApiTest extends BaseIT {
       .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
 
     wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=false", PRIMARY_REQUEST_ID)))
+      String.format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
       .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
       .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
 
@@ -185,7 +185,7 @@ class AllowedServicePointsApiTest extends BaseIT {
       .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
 
     wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=false", PRIMARY_REQUEST_ID)))
+      String.format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
       .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
       .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
 


### PR DESCRIPTION
## Purpose
Add support for operation `replace` in Allowed Service Points API.
[MODTLR-56](https://folio-org.atlassian.net/browse/MODTLR-56)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
