### PR TITLE
[MODTLR-43] Reorder secondary requests in sync with primary requests [Part 2]

### DIFF
--- a/src/main/java/org/folio/client/feign/RequestCirculationClient.java
+++ b/src/main/java/org/folio/client/feign/RequestCirculationClient.java
@@ -1,14 +1,21 @@
 package org.folio.client.feign;
 
+import org.folio.domain.dto.ReorderQueue;
 import org.folio.domain.dto.Requests;
 import org.folio.spring.config.FeignClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "circulation-request", url = "circulation/requests", configuration = FeignClientConfiguration.class)
 public interface RequestCirculationClient {
 
   @GetMapping("/queue/instance/{instanceId}")
   Requests getRequestsQueueByInstanceId(@PathVariable String instanceId);
+
+  @PostMapping("/queue/instance/{instanceId}/reorder")
+  Requests reorderRequestsQueueForInstanceId(@PathVariable String instanceId,
+    @RequestBody ReorderQueue reorderQueue);
 }

--- a/src/main/java/org/folio/service/RequestService.java
+++ b/src/main/java/org/folio/service/RequestService.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.folio.domain.RequestWrapper;
+import org.folio.domain.dto.ReorderQueue;
 import org.folio.domain.dto.Request;
 
 public interface RequestService {
@@ -14,5 +15,7 @@ public interface RequestService {
 
   Request getRequestFromStorage(String requestId, String tenantId);
   Request updateRequestInStorage(Request request, String tenantId);
-  List<Request> getRequestsByInstanceId(String instanceId);
+  List<Request> getRequestsQueueByInstanceId(String instanceId, String tenantId);
+  List<Request> getRequestsQueueByInstanceId(String instanceId);
+  List<Request> reorderRequestsQueueForInstance(String instanceId, String tenantId, ReorderQueue reorderQueue);
 }

--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -45,12 +45,14 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
     log.info("updateQueuePositions:: parameters instanceId: {}", instanceId);
 
     var unifiedQueue = requestService.getRequestsByInstanceId(instanceId);
+    log.info("updateQueuePositions:: unifiedQueue: {}", unifiedQueue);
 
     List<UUID> sortedPrimaryRequestIds = unifiedQueue.stream()
       .filter(request -> PRIMARY == request.getEcsRequestPhase())
       .sorted(Comparator.comparing(Request::getPosition))
       .map(request -> UUID.fromString(request.getId()))
       .toList();
+    log.info("updateQueuePositions:: sortedPrimaryRequestIds: {}", sortedPrimaryRequestIds);
 
     List<EcsTlrEntity> sortedEcsTlrQueue = sortEcsTlrEntities(sortedPrimaryRequestIds,
       ecsTlrRepository.findByPrimaryRequestIdIn(sortedPrimaryRequestIds));

--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -22,7 +22,6 @@ import org.folio.domain.entity.EcsTlrEntity;
 import org.folio.repository.EcsTlrRepository;
 import org.folio.service.KafkaEventHandler;
 import org.folio.service.RequestService;
-import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.support.KafkaEvent;
 import org.springframework.stereotype.Service;
 
@@ -120,7 +119,6 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
         correctOrder), tenantId));
   }
 
-  //  private void reorderSecondaryRequestsForTenant(String tenantId, List<Request> secondaryRequests,
   private List<Request> reorderSecondaryRequestsForTenant(String tenantId,
     List<Request> secondaryRequests, Map<UUID, Integer> correctOrder) {
 

--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -78,6 +78,8 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
   private List<EcsTlrEntity> sortEcsTlrEntities(List<UUID> sortedPrimaryRequestIds,
     List<EcsTlrEntity> ecsTlrQueue) {
 
+    log.info("sortEcsTlrEntities:: parameters sortedPrimaryRequestIds: {}, ecsTlrQueue: {}",
+      sortedPrimaryRequestIds, ecsTlrQueue);
     Map<UUID, EcsTlrEntity> ecsTlrByPrimaryRequestId = ecsTlrQueue.stream()
       .collect(toMap(EcsTlrEntity::getPrimaryRequestId, Function.identity()));
     List<EcsTlrEntity> sortedEcsTlrQueue = sortedPrimaryRequestIds

--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -54,8 +54,14 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
       .toList();
     log.info("updateQueuePositions:: sortedPrimaryRequestIds: {}", sortedPrimaryRequestIds);
 
+    List<EcsTlrEntity> ecsTlrByPrimaryRequests = ecsTlrRepository.findByPrimaryRequestIdIn(
+      sortedPrimaryRequestIds);
+    if (ecsTlrByPrimaryRequests == null || ecsTlrByPrimaryRequests.isEmpty()) {
+      log.warn("updateQueuePositions:: no corresponding ECS TLR found");
+      return;
+    }
     List<EcsTlrEntity> sortedEcsTlrQueue = sortEcsTlrEntities(sortedPrimaryRequestIds,
-      ecsTlrRepository.findByPrimaryRequestIdIn(sortedPrimaryRequestIds));
+      ecsTlrByPrimaryRequests);
     Map<String, List<Request>> groupedSecondaryRequestsByTenantId = groupSecondaryRequestsByTenantId(
       sortedEcsTlrQueue);
 

--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -52,6 +52,7 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
 
     List<UUID> sortedPrimaryRequestIds = unifiedQueue.stream()
       .filter(request -> PRIMARY == request.getEcsRequestPhase())
+      .filter(request -> request.getPosition() != null)
       .sorted(Comparator.comparing(Request::getPosition))
       .map(request -> UUID.fromString(request.getId()))
       .toList();

--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -9,6 +9,7 @@ import org.folio.client.feign.CirculationClient;
 import org.folio.client.feign.RequestCirculationClient;
 import org.folio.client.feign.RequestStorageClient;
 import org.folio.domain.RequestWrapper;
+import org.folio.domain.dto.ReorderQueue;
 import org.folio.domain.dto.Request;
 import org.folio.domain.dto.ServicePoint;
 import org.folio.domain.dto.User;
@@ -119,8 +120,31 @@ public class RequestServiceImpl implements RequestService {
   }
 
   @Override
-  public List<Request> getRequestsByInstanceId(String instanceId) {
+  public List<Request> getRequestsQueueByInstanceId(String instanceId, String tenantId) {
+    log.info("getRequestsQueueByInstanceId:: parameters instanceId: {}, tenantId: {}",
+      instanceId, tenantId);
+
+    return executionService.executeSystemUserScoped(tenantId,
+      () -> requestCirculationClient.getRequestsQueueByInstanceId(instanceId).getRequests());
+  }
+
+  @Override
+  public List<Request> getRequestsQueueByInstanceId(String instanceId) {
+    log.info("getRequestsQueueByInstanceId:: parameters instanceId: {}", instanceId);
+
     return requestCirculationClient.getRequestsQueueByInstanceId(instanceId).getRequests();
+  }
+
+  @Override
+  public List<Request> reorderRequestsQueueForInstance(String instanceId, String tenantId,
+    ReorderQueue reorderQueue) {
+
+    log.info("reorderRequestsQueueForInstance:: parameters instanceId: {}, tenantId: {}, " +
+        "reorderQueue: {}", instanceId, tenantId, reorderQueue);
+
+    return executionService.executeSystemUserScoped(tenantId,
+      () -> requestCirculationClient.reorderRequestsQueueForInstanceId(instanceId, reorderQueue)
+        .getRequests());
   }
 
   private void cloneRequester(User primaryRequestRequester) {

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -9,6 +9,7 @@ search.instances.collection.get
 circulation.requests.instances.item.post
 circulation.requests.item.post
 circulation.requests.queue.collection.get
+circulation.requests.queue.reorder.collection.post
 circulation-storage.requests.item.get
 circulation-storage.requests.collection.get
 circulation-storage.requests.item.put

--- a/src/main/resources/swagger.api/ecs-tlr.yaml
+++ b/src/main/resources/swagger.api/ecs-tlr.yaml
@@ -117,6 +117,8 @@ components:
       $ref: schemas/userGroup.json
     requestsBatchUpdate:
       $ref: schemas/requests-batch-update.json
+    reorderQueue:
+      $ref: schemas/reorder-queue.json
   parameters:
     requestId:
       name: requestId

--- a/src/main/resources/swagger.api/schemas/reorder-queue.json
+++ b/src/main/resources/swagger.api/schemas/reorder-queue.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Reordered queue",
+  "description": "New positions for all requests in the queue",
+  "type": "object",
+  "properties": {
+    "reorderedQueue" : {
+      "type": "array",
+      "description": "All request from the item queue and their's new positions in the queue.",
+      "items": {
+        "description": "Reorder request",
+        "type": "object",
+        "properties": {
+          "id" : {
+            "description": "Request id",
+            "type": "string",
+            "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+          },
+          "newPosition": {
+            "description": "New position for the request",
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "newPosition"
+        ]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "reorderedQueue"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/reorder-queue.json
+++ b/src/main/resources/swagger.api/schemas/reorder-queue.json
@@ -14,7 +14,7 @@
           "id" : {
             "description": "Request id",
             "type": "string",
-            "pattern" : "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+            "$ref": "uuid.json"
           },
           "newPosition": {
             "description": "New position for the request",

--- a/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
+++ b/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
@@ -1,8 +1,10 @@
 package org.folio.service;
 
+import static org.folio.support.KafkaEvent.EventType.CREATED;
 import static org.folio.support.KafkaEvent.EventType.UPDATED;
 import static org.folio.util.TestUtils.buildEvent;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +17,8 @@ import java.util.stream.Stream;
 
 import org.folio.api.BaseIT;
 import org.folio.domain.dto.EcsTlr;
+import org.folio.domain.dto.ReorderQueue;
+import org.folio.domain.dto.ReorderQueueReorderedQueueInner;
 import org.folio.domain.dto.Request;
 import org.folio.domain.dto.RequestsBatchUpdate;
 import org.folio.domain.mapper.EcsTlrMapperImpl;
@@ -40,7 +44,7 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
   private KafkaEventListener eventListener;
 
   @Test
-  void shouldUpdateSecondaryRequestPositionsWhenPrimaryRequestsPositionsChanged() {
+  void shouldReorderTwoSecondaryRequestsWhenPrimaryRequestsReordered() {
     var requesterId = randomId();
     var pickupServicePointId = randomId();
     var instanceId = randomId();
@@ -81,23 +85,38 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
         fourthPrimaryRequest)
       .sorted(Comparator.comparing(Request::getPosition))
       .toList();
-
-    when(requestService.getRequestsByInstanceId(any())).thenReturn(requestsQueue);
+    when(requestService.getRequestsQueueByInstanceId(any())).thenReturn(requestsQueue);
+    when(requestService.getRequestsQueueByInstanceId(any(), eq(firstTenant))).thenReturn(
+      List.of(firstSecondaryRequest, secondSecondaryRequest));
+    when(requestService.getRequestsQueueByInstanceId(any(), eq(secondTenant))).thenReturn(
+      List.of(thirdSecondaryRequest, fourthSecondaryRequest));
     when(ecsTlrRepository.findByPrimaryRequestIdIn(any())).thenReturn(List.of(
       ecsTlrMapper.mapDtoToEntity(firstEcsTlr), ecsTlrMapper.mapDtoToEntity(secondEcsTlr),
       ecsTlrMapper.mapDtoToEntity(thirdEcsTlr), ecsTlrMapper.mapDtoToEntity(fourthEcsTlr)));
 
-    eventListener.handleRequestBatchUpdateEvent(serializeEvent(buildEvent(CENTRAL_TENANT_ID, UPDATED,
+    List<Request> secRequestsWithUpdatedPositions = List.of(
+      new Request()
+        .id(firstSecondaryRequest.getId())
+        .position(2),
+      new Request()
+        .id(secondSecondaryRequest.getId())
+        .position(1));
+    ReorderQueue reorderQueue = createReorderQueue(secRequestsWithUpdatedPositions);
+    when(requestService.reorderRequestsQueueForInstance(instanceId, firstTenant, reorderQueue))
+      .thenReturn(secRequestsWithUpdatedPositions);
+
+    eventListener.handleRequestBatchUpdateEvent(serializeEvent(buildEvent(CENTRAL_TENANT_ID, CREATED,
       null, new RequestsBatchUpdate().instanceId(instanceId))), getMessageHeaders(
         CENTRAL_TENANT_ID, CENTRAL_TENANT_ID));
-    verify(requestService, times(1)).updateRequestInStorage(firstSecondaryRequest, firstTenant);
-    verify(requestService, times(1)).updateRequestInStorage(secondSecondaryRequest, firstTenant);
-    verify(requestService, times(0)).updateRequestInStorage(thirdSecondaryRequest, secondTenant);
-    verify(requestService, times(0)).updateRequestInStorage(fourthSecondaryRequest, secondTenant);
+
+    verify(requestService, times(1)).reorderRequestsQueueForInstance(
+      eq(instanceId), eq(firstTenant), eq(reorderQueue));
+    verify(requestService, times(0)).reorderRequestsQueueForInstance(
+      eq(instanceId), eq(secondTenant), any());
   }
 
   @Test
-  void shouldReorderSecondaryRequestsFollowingChangesInPrimaryRequestOrder() {
+  void shouldReorderThreeSecondaryRequestsWhenPrimaryRequestsReordered() {
     var requesterId = randomId();
     var pickupServicePointId = randomId();
     var instanceId = randomId();
@@ -106,14 +125,14 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
 
     var firstEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var secondEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
-    var thirdEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
-    var fourthEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
+    var thirdEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
+    var fourthEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var fifthEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
 
     var firstSecondaryRequest = buildSecondaryRequest(firstEcsTlr, 1);
     var secondSecondaryRequest = buildSecondaryRequest(secondEcsTlr, 2);
-    var thirdSecondaryRequest = buildSecondaryRequest(thirdEcsTlr, 3);
-    var fourthSecondaryRequest = buildSecondaryRequest(fourthEcsTlr, 1);
+    var thirdSecondaryRequest = buildSecondaryRequest(thirdEcsTlr, 1);
+    var fourthSecondaryRequest = buildSecondaryRequest(fourthEcsTlr, 3);
     var fifthSecondaryRequest = buildSecondaryRequest(fifthEcsTlr, 2);
 
     var firstPrimaryRequest = buildPrimaryRequest(firstEcsTlr, firstSecondaryRequest, 1);
@@ -141,22 +160,40 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
     when(requestService.getRequestFromStorage(fifthEcsTlr.getSecondaryRequestId(),
       fifthEcsTlr.getSecondaryRequestTenantId()))
       .thenReturn(fifthSecondaryRequest);
-    when(requestService.getRequestsByInstanceId(any()))
+    when(requestService.getRequestsQueueByInstanceId(any()))
       .thenReturn(List.of(firstPrimaryRequest, reorderedSecondPrimaryRequest, thirdPrimaryRequest,
         fourthPrimaryRequest, fifthPrimaryRequest));
+    when(requestService.getRequestsQueueByInstanceId(any(), eq(firstTenant))).thenReturn(
+      List.of(firstSecondaryRequest, secondSecondaryRequest, fourthSecondaryRequest));
+    when(requestService.getRequestsQueueByInstanceId(any(), eq(secondTenant))).thenReturn(
+      List.of(thirdSecondaryRequest, fifthSecondaryRequest));
+
     when(ecsTlrRepository.findByPrimaryRequestIdIn(any())).thenReturn(List.of(
       ecsTlrMapper.mapDtoToEntity(firstEcsTlr), ecsTlrMapper.mapDtoToEntity(secondEcsTlr),
       ecsTlrMapper.mapDtoToEntity(thirdEcsTlr), ecsTlrMapper.mapDtoToEntity(fourthEcsTlr),
       ecsTlrMapper.mapDtoToEntity(fifthEcsTlr)));
+    List<Request> secRequestsWithUpdatedPositions = List.of(
+      new Request()
+        .id(firstSecondaryRequest.getId())
+        .position(1),
+      new Request()
+        .id(secondSecondaryRequest.getId())
+        .position(3),
+      new Request()
+        .id(fourthSecondaryRequest.getId())
+        .position(2));
+    ReorderQueue reorderQueue = createReorderQueue(secRequestsWithUpdatedPositions);
+    when(requestService.reorderRequestsQueueForInstance(instanceId, firstTenant, reorderQueue))
+      .thenReturn(secRequestsWithUpdatedPositions);
 
     eventListener.handleRequestBatchUpdateEvent(serializeEvent(buildEvent(CENTRAL_TENANT_ID, UPDATED,
       null, new RequestsBatchUpdate().instanceId(instanceId))), getMessageHeaders(
         CENTRAL_TENANT_ID, CENTRAL_TENANT_ID));
-    verify(requestService, times(0)).updateRequestInStorage(firstSecondaryRequest, firstTenant);
-    verify(requestService, times(1)).updateRequestInStorage(secondSecondaryRequest, firstTenant);
-    verify(requestService, times(1)).updateRequestInStorage(thirdSecondaryRequest, firstTenant);
-    verify(requestService, times(0)).updateRequestInStorage(fourthSecondaryRequest, secondTenant);
-    verify(requestService, times(0)).updateRequestInStorage(fifthSecondaryRequest, secondTenant);
+
+    verify(requestService, times(1)).reorderRequestsQueueForInstance(
+      eq(instanceId), eq(firstTenant), eq(reorderQueue));
+    verify(requestService, times(0)).reorderRequestsQueueForInstance(
+      eq(instanceId), eq(secondTenant), any());
   }
 
   private static EcsTlr buildEcsTlr(String instanceId, String requesterId,
@@ -215,5 +252,13 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
   @SneakyThrows
   private String serializeEvent(KafkaEvent<RequestsBatchUpdate> event) {
     return new ObjectMapper().writeValueAsString(event);
+  }
+
+  private ReorderQueue createReorderQueue(List<Request> requests) {
+    ReorderQueue reorderQueue = new ReorderQueue();
+    requests.forEach(request -> reorderQueue.addReorderedQueueItem(new ReorderQueueReorderedQueueInner(
+      request.getId(), request.getPosition())));
+
+    return reorderQueue;
   }
 }

--- a/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
+++ b/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
@@ -47,15 +47,14 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
   private EcsTlrRepository ecsTlrRepository;
   @Autowired
   private KafkaEventListener eventListener;
+  String requesterId = randomId();
+  String pickupServicePointId = randomId();
+  String instanceId = randomId();
+  String firstTenant = "tenant1";
+  String secondTenant = "tenant2";
 
   @Test
   void shouldReorderTwoSecondaryRequestsWhenPrimaryRequestsReordered() {
-    var requesterId = randomId();
-    var pickupServicePointId = randomId();
-    var instanceId = randomId();
-    var firstTenant = "tenant1";
-    var secondTenant = "tenant2";
-
     var firstEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var secondEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var thirdEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
@@ -122,12 +121,6 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
 
   @Test
   void shouldReorderThreeSecondaryRequestsWhenPrimaryRequestsReordered() {
-    var requesterId = randomId();
-    var pickupServicePointId = randomId();
-    var instanceId = randomId();
-    var firstTenant = "tenant1";
-    var secondTenant = "tenant2";
-
     var firstEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var secondEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var thirdEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
@@ -203,12 +196,6 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
 
   @Test
   void shouldNotReorderSecondaryRequestsWhenPrimaryRequestsOrderIsUnchanged() {
-    var requesterId = randomId();
-    var pickupServicePointId = randomId();
-    var instanceId = randomId();
-    var firstTenant = "tenant1";
-    var secondTenant = "tenant2";
-
     var firstEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var secondEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var thirdEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, secondTenant);
@@ -266,12 +253,6 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
   @MethodSource("provideLists")
   void shouldNotReorderSecondaryRequestsWhenPrimaryRequestsAreNullOrEmtpy(
     List<EcsTlrEntity> primaryRequests) {
-
-    var requesterId = randomId();
-    var pickupServicePointId = randomId();
-    var instanceId = randomId();
-    var firstTenant = "tenant1";
-    var secondTenant = "tenant2";
 
     var firstEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);
     var secondEcsTlr = buildEcsTlr(instanceId, requesterId, pickupServicePointId, firstTenant);

--- a/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
+++ b/src/test/java/org/folio/service/RequestBatchUpdateEventHandlerTest.java
@@ -114,7 +114,7 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
         CENTRAL_TENANT_ID, CENTRAL_TENANT_ID));
 
     verify(requestService, times(1)).reorderRequestsQueueForInstance(
-      eq(instanceId), eq(firstTenant), eq(reorderQueue));
+      instanceId, firstTenant, reorderQueue);
     verify(requestService, times(0)).reorderRequestsQueueForInstance(
       eq(instanceId), eq(secondTenant), any());
   }
@@ -189,7 +189,7 @@ class RequestBatchUpdateEventHandlerTest extends BaseIT {
         CENTRAL_TENANT_ID, CENTRAL_TENANT_ID));
 
     verify(requestService, times(1)).reorderRequestsQueueForInstance(
-      eq(instanceId), eq(firstTenant), eq(reorderQueue));
+      instanceId, firstTenant, reorderQueue);
     verify(requestService, times(0)).reorderRequestsQueueForInstance(
       eq(instanceId), eq(secondTenant), any());
   }


### PR DESCRIPTION
## Purpose
Handle Kafka event generated on request update.

When updated request is a primary request (ecsRequestPhase=Primary) and its position updated, secondary request should also be updated.

Load the queue of the primary request (TLR is enabled, it should be a unified queue - all requests with the same instanceId)

Find primary requests in this queue and get their corresponding secondary requests.

Load all request queues for all of the secondary requests (again, unified queues because TLR should always be enabled in data tenants in Phase I). There could be multiple such queues because secondary requests could be located in different tenants.

For each of the secondary request queues:

Check if secondary requests in the queue have the same order (not necessarily same positions) as their corresponding primary requests. If they do, skip this queue.

If they don’t, reorder secondary requests to match the order (not necessarily the positions) of their corresponding primary requests. One way to do this is to give them positions starting from 1 and then put all of the non-ECS requests at the end of the queue.

Update secondary requests with their new positions

Resolves: [MODTLR-43](https://folio-org.atlassian.net/browse/MODTLR-43)