### PR TITLE
MODTLR-67: Get token from headers as a fallback

### DIFF
--- a/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestBatchUpdateEventHandler.java
@@ -48,7 +48,7 @@ public class RequestBatchUpdateEventHandler implements KafkaEventHandler<Request
     log.info("updateQueuePositions:: parameters instanceId: {}", instanceId);
 
     var unifiedQueue = requestService.getRequestsQueueByInstanceId(instanceId);
-    log.info("updateQueuePositions:: unifiedQueue: {}", unifiedQueue);
+    log.debug("updateQueuePositions:: unifiedQueue: {}", unifiedQueue);
 
     List<UUID> sortedPrimaryRequestIds = unifiedQueue.stream()
       .filter(request -> PRIMARY == request.getEcsRequestPhase())

--- a/src/main/java/org/folio/util/HttpUtils.java
+++ b/src/main/java/org/folio/util/HttpUtils.java
@@ -40,7 +40,7 @@ public class HttpUtils {
       .map(ServletRequestAttributes::getRequest);
   }
 
-  private Optional<String> getToken(HttpServletRequest request) {
+  private static Optional<String> getToken(HttpServletRequest request) {
     return getCookie(request, ACCESS_TOKEN_COOKIE_NAME)
       .or(() -> Optional.ofNullable(request.getHeader(XOkapiHeaders.TOKEN)));
   }

--- a/src/main/java/org/folio/util/HttpUtils.java
+++ b/src/main/java/org/folio/util/HttpUtils.java
@@ -5,6 +5,7 @@ import java.util.Base64;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.spring.integration.XOkapiHeaders;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -23,9 +24,13 @@ public class HttpUtils {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public static Optional<String> getTenantFromToken() {
-    return getCurrentRequest()
-      .flatMap(request -> getCookie(request, ACCESS_TOKEN_COOKIE_NAME))
+    return getToken()
       .flatMap(HttpUtils::extractTenantFromToken);
+  }
+
+  public static Optional<String> getToken() {
+    return getCurrentRequest()
+      .flatMap(HttpUtils::getToken);
   }
 
   public static Optional<HttpServletRequest> getCurrentRequest() {
@@ -35,7 +40,12 @@ public class HttpUtils {
       .map(ServletRequestAttributes::getRequest);
   }
 
-  public static Optional<String> getCookie(HttpServletRequest request, String cookieName) {
+  private Optional<String> getToken(HttpServletRequest request) {
+    return getCookie(request, ACCESS_TOKEN_COOKIE_NAME)
+      .or(() -> Optional.ofNullable(request.getHeader(XOkapiHeaders.TOKEN)));
+  }
+
+  private static Optional<String> getCookie(HttpServletRequest request, String cookieName) {
     return Optional.ofNullable(request)
       .map(HttpServletRequest::getCookies)
       .flatMap(cookies -> getCookie(cookies, cookieName))

--- a/src/main/java/org/folio/util/HttpUtils.java
+++ b/src/main/java/org/folio/util/HttpUtils.java
@@ -24,13 +24,9 @@ public class HttpUtils {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public static Optional<String> getTenantFromToken() {
-    return getToken()
-      .flatMap(HttpUtils::extractTenantFromToken);
-  }
-
-  public static Optional<String> getToken() {
     return getCurrentRequest()
-      .flatMap(HttpUtils::getToken);
+      .flatMap(HttpUtils::getToken)
+      .flatMap(HttpUtils::extractTenantFromToken);
   }
 
   public static Optional<HttpServletRequest> getCurrentRequest() {

--- a/src/main/java/org/folio/util/HttpUtils.java
+++ b/src/main/java/org/folio/util/HttpUtils.java
@@ -42,10 +42,16 @@ public class HttpUtils {
 
   private static Optional<String> getToken(HttpServletRequest request) {
     return getCookie(request, ACCESS_TOKEN_COOKIE_NAME)
-      .or(() -> Optional.ofNullable(request.getHeader(XOkapiHeaders.TOKEN)));
+      .or(() -> getHeader(request, XOkapiHeaders.TOKEN));
+  }
+
+  private static Optional<String> getHeader(HttpServletRequest request, String headerName) {
+    log.info("getHeader:: looking for header '{}'", headerName);
+    return Optional.ofNullable(request.getHeader(headerName));
   }
 
   private static Optional<String> getCookie(HttpServletRequest request, String cookieName) {
+    log.info("getCookie:: looking for cookie '{}'", cookieName);
     return Optional.ofNullable(request)
       .map(HttpServletRequest::getCookies)
       .flatMap(cookies -> getCookie(cookies, cookieName))

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -76,8 +76,6 @@ class EcsTlrApiTest extends BaseIT {
   private static final Date REQUEST_DATE = new Date();
   private static final Date REQUEST_EXPIRATION_DATE = new Date();
 
-
-
   @BeforeEach
   public void beforeEach() {
     wireMockServer.resetAll();

--- a/src/test/java/org/folio/util/HttpUtilsTest.java
+++ b/src/test/java/org/folio/util/HttpUtilsTest.java
@@ -12,7 +12,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.Cookie;
 
-public class HttpUtilsTest {
+class HttpUtilsTest {
 
   @AfterEach
   void tearDown() {

--- a/src/test/java/org/folio/util/HttpUtilsTest.java
+++ b/src/test/java/org/folio/util/HttpUtilsTest.java
@@ -2,6 +2,7 @@ package org.folio.util;
 
 import static org.folio.util.TestUtils.buildToken;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,13 @@ public class HttpUtilsTest {
 
     String tenantFromToken = HttpUtils.getTenantFromToken().orElseThrow();
     assertEquals(tenantFromHeaders, tenantFromToken);
+  }
+
+  @Test
+  void tenantIsNotFound() {
+    RequestContextHolder.setRequestAttributes(
+      new ServletRequestAttributes(new MockHttpServletRequest()));
+    assertTrue(HttpUtils.getTenantFromToken().isEmpty());
   }
 
 }

--- a/src/test/java/org/folio/util/HttpUtilsTest.java
+++ b/src/test/java/org/folio/util/HttpUtilsTest.java
@@ -1,0 +1,45 @@
+package org.folio.util;
+
+import static org.folio.util.TestUtils.buildToken;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.Cookie;
+
+public class HttpUtilsTest {
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void tenantIsExtractedFromCookies() {
+    String tenantFromCookies = "tenant_from_cookies";
+    String tenantFromHeaders = "tenant_from_headers";
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setCookies(new Cookie("folioAccessToken", buildToken(tenantFromCookies)));
+    request.addHeader("x-okapi-token", buildToken(tenantFromHeaders));
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    String tenantFromToken = HttpUtils.getTenantFromToken().orElseThrow();
+    assertEquals(tenantFromCookies, tenantFromToken);
+  }
+
+  @Test
+  void tenantIsExtractedFromHeaders() {
+    String tenantFromHeaders = "tenant_from_headers";
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("x-okapi-token", buildToken(tenantFromHeaders));
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    String tenantFromToken = HttpUtils.getTenantFromToken().orElseThrow();
+    assertEquals(tenantFromHeaders, tenantFromToken);
+  }
+
+}


### PR DESCRIPTION
## Purpose
When creating an ECS TLR, mod-tlr determines borrowing tenant ID by extracting it from the token stored in the request cookies. But when the request is made using a system user (provided by folio-spring-system-user library), the token is always moved from cookies to “x-okapi-token” header. So when we can’t find the token in the cookies, we need to look in the headers as well.

[MODTLR-67](https://folio-org.atlassian.net/browse/MODTLR-67)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
