### PR TITLE
MODTLR-68: Allowed service points - only use lending side circulation rules

### DIFF
--- a/src/main/java/org/folio/client/feign/CirculationClient.java
+++ b/src/main/java/org/folio/client/feign/CirculationClient.java
@@ -18,30 +18,19 @@ public interface CirculationClient {
   Request createRequest(Request request);
 
   @GetMapping("/requests/allowed-service-points")
-  AllowedServicePointsResponse allowedServicePointsWithStubItem(
-    @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
-    @RequestParam("operation") String operation, @RequestParam("useStubItem") boolean useStubItem);
-
-  @GetMapping("/requests/allowed-service-points")
-  AllowedServicePointsResponse allowedServicePointsWithStubItem(
-    @RequestParam("operation") String operation, @RequestParam("requestId") String requestId,
-    @RequestParam("useStubItem") boolean useStubItem);
-
-  @GetMapping("/requests/allowed-service-points")
-  AllowedServicePointsResponse allowedRoutingServicePoints(
-    @RequestParam("patronGroupId") String patronGroupId, @RequestParam("instanceId") String instanceId,
-    @RequestParam("operation") String operation,
-    @RequestParam("ecsRequestRouting") boolean ecsRequestRouting);
-
-  @GetMapping("/requests/allowed-service-points")
-  AllowedServicePointsResponse allowedRoutingServicePoints(
-    @RequestParam("operation") String operation, @RequestParam("requestId") String requestId,
-    @RequestParam("ecsRequestRouting") boolean ecsRequestRouting);
-
-  @GetMapping("/requests/allowed-service-points")
-  AllowedServicePointsResponse allowedRoutingServicePoints(
+  AllowedServicePointsResponse allowedServicePointsByInstance(
     @RequestParam("patronGroupId") String patronGroupId,
     @RequestParam("operation") String operation,
-    @RequestParam("ecsRequestRouting") boolean ecsRequestRouting,
+    @RequestParam("instanceId") String instanceId);
+
+  @GetMapping("/requests/allowed-service-points")
+  AllowedServicePointsResponse allowedServicePointsByItem(
+    @RequestParam("patronGroupId") String patronGroupId,
+    @RequestParam("operation") String operation,
     @RequestParam("itemId") String itemId);
+
+  @GetMapping("/requests/allowed-service-points")
+  AllowedServicePointsResponse allowedServicePoints(
+    @RequestParam("operation") String operation,
+    @RequestParam("requestId") String requestId);
 }

--- a/src/main/java/org/folio/controller/AllowedServicePointsController.java
+++ b/src/main/java/org/folio/controller/AllowedServicePointsController.java
@@ -43,6 +43,7 @@ public class AllowedServicePointsController implements AllowedServicePointsApi {
       ? allowedServicePointsForTitleLevelRequestService
       : allowedServicePointsForItemLevelRequestService;
     var response = allowedServicePointsService.getAllowedServicePoints(request);
+    
     return ResponseEntity.status(OK).body(response);
   }
 

--- a/src/main/java/org/folio/controller/AllowedServicePointsController.java
+++ b/src/main/java/org/folio/controller/AllowedServicePointsController.java
@@ -42,9 +42,9 @@ public class AllowedServicePointsController implements AllowedServicePointsApi {
     var allowedServicePointsService = request.isForTitleLevelRequest()
       ? allowedServicePointsForTitleLevelRequestService
       : allowedServicePointsForItemLevelRequestService;
-    var response = allowedServicePointsService.getAllowedServicePoints(request);
-    
-    return ResponseEntity.status(OK).body(response);
+
+    return ResponseEntity.status(OK).body(allowedServicePointsService
+      .getAllowedServicePoints(request));
   }
 
   private static boolean validateAllowedServicePointsRequest(AllowedServicePointsRequest request) {

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsForItemLevelRequestService.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsForItemLevelRequestService.java
@@ -44,7 +44,7 @@ public class AllowedServicePointsForItemLevelRequestService extends AllowedServi
   protected AllowedServicePointsResponse getAllowedServicePointsFromTenant(
     AllowedServicePointsRequest request, String patronGroupId, String tenantId) {
 
-    log.info("getAllowedServicePointsFromLendingTenant:: parameters: request: {}, " +
+    log.info("getAllowedServicePointsFromTenant:: parameters: request: {}, " +
       "patronGroupId: {}, tenantId: {}", request, patronGroupId, tenantId);
 
     return executionService.executeSystemUserScoped(tenantId,

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsForItemLevelRequestService.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsForItemLevelRequestService.java
@@ -41,15 +41,15 @@ public class AllowedServicePointsForItemLevelRequestService extends AllowedServi
   }
 
   @Override
-  protected AllowedServicePointsResponse getAllowedServicePointsFromLendingTenant(
+  protected AllowedServicePointsResponse getAllowedServicePointsFromTenant(
     AllowedServicePointsRequest request, String patronGroupId, String tenantId) {
 
     log.info("getAllowedServicePointsFromLendingTenant:: parameters: request: {}, " +
       "patronGroupId: {}, tenantId: {}", request, patronGroupId, tenantId);
 
     return executionService.executeSystemUserScoped(tenantId,
-      () -> circulationClient.allowedRoutingServicePoints(patronGroupId,
-        request.getOperation().getValue(), true, request.getItemId()));
+      () -> circulationClient.allowedServicePointsByItem(patronGroupId,
+        request.getOperation().getValue(), request.getItemId()));
   }
 
 }

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsForTitleLevelRequestService.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsForTitleLevelRequestService.java
@@ -48,12 +48,12 @@ public class AllowedServicePointsForTitleLevelRequestService extends AllowedServ
   }
 
   @Override
-  protected AllowedServicePointsResponse getAllowedServicePointsFromLendingTenant(
+  protected AllowedServicePointsResponse getAllowedServicePointsFromTenant(
     AllowedServicePointsRequest request, String patronGroupId, String tenantId) {
 
     return executionService.executeSystemUserScoped(tenantId,
-      () -> circulationClient.allowedRoutingServicePoints(patronGroupId, request.getInstanceId(),
-        request.getOperation().getValue(), true));
+      () -> circulationClient.allowedServicePointsByInstance(patronGroupId,
+        request.getOperation().getValue(), request.getInstanceId()));
   }
 
 }

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
@@ -78,7 +78,7 @@ public abstract class AllowedServicePointsServiceImpl implements AllowedServiceP
     }
     toAdd.stream()
       .filter(Objects::nonNull)
-      .forEach(t -> servicePoints.put(t.getId(), t));
+      .forEach(allowedSp -> servicePoints.put(allowedSp.getId(), allowedSp));
   }
 
   protected abstract Collection<String> getLendingTenants(AllowedServicePointsRequest request);

--- a/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/AllowedServicePointsServiceImpl.java
@@ -89,7 +89,7 @@ public abstract class AllowedServicePointsServiceImpl implements AllowedServiceP
   private AllowedServicePointsResponse getForReplace(AllowedServicePointsRequest request) {
     EcsTlrEntity ecsTlr = findEcsTlr(request);
 
-    log.info("getForReplace:: fetching allowed service points from borrowing tenant");
+    log.info("getForReplace:: fetching allowed service points from secondary request tenant");
     var allowedServicePoints = executionService.executeSystemUserScoped(
       ecsTlr.getSecondaryRequestTenantId(), () -> circulationClient.allowedServicePoints(
         REPLACE.getValue(), ecsTlr.getSecondaryRequestId().toString()));
@@ -97,8 +97,7 @@ public abstract class AllowedServicePointsServiceImpl implements AllowedServiceP
     Request secondaryRequest = requestService.getRequestFromStorage(
       ecsTlr.getSecondaryRequestId().toString(), ecsTlr.getSecondaryRequestTenantId());
     Request.RequestTypeEnum secondaryRequestType = secondaryRequest.getRequestType();
-    log.info("isRequestingNotAllowedInLendingTenant:: secondary request type: {}",
-      secondaryRequestType.getValue());
+    log.info("getForReplace:: secondary request type: {}", secondaryRequestType.getValue());
 
     return switch (secondaryRequestType) {
       case PAGE -> new AllowedServicePointsResponse().page(allowedServicePoints.getPage());

--- a/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
+++ b/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
@@ -7,8 +7,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static java.lang.String.format;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Set;
@@ -26,6 +24,8 @@ import org.folio.domain.entity.EcsTlrEntity;
 import org.folio.repository.EcsTlrRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class AllowedServicePointsApiTest extends BaseIT {
@@ -43,7 +43,7 @@ class AllowedServicePointsApiTest extends BaseIT {
     ALLOWED_SERVICE_POINTS_URL + "?operation=replace&requestId=" + PRIMARY_REQUEST_ID;
   private static final String ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL =
     "/circulation/requests/allowed-service-points";
-  private static final String ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN =
+  private static final String ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN =
     ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL + ".*";
   private static final String SEARCH_INSTANCES_URL = "/search/instances.*";
   private static final String USER_URL = "/users/" + REQUESTER_ID;
@@ -60,13 +60,21 @@ class AllowedServicePointsApiTest extends BaseIT {
   }
 
   @Test
-  void allowedServicePointReturnsEmptyResultWhenNoRoutingSpInResponsesFromDataTenants() {
-    var item1 = new SearchItem();
-    item1.setTenantId(TENANT_ID_UNIVERSITY);
+  void allowedServicePointsShouldReturn422WhenParametersAreInvalid() {
+    doGet(ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s", randomId()))
+      .expectStatus().isEqualTo(422);
+  }
 
-    var item2 = new SearchItem();
-    item2.setTenantId(TENANT_ID_COLLEGE);
+  @Test
+  void titleLevelCreateWhenNoSpInDataTenants() {
+    // given
+    User requester = new User().patronGroup(PATRON_GROUP_ID);
+    wireMockServer.stubFor(get(urlMatching(USER_URL))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .willReturn(jsonResponse(asJsonString(requester), SC_OK)));
 
+    var item1 = new SearchItem().tenantId(TENANT_ID_UNIVERSITY);
+    var item2 = new SearchItem().tenantId(TENANT_ID_COLLEGE);
     var searchInstancesResponse = new SearchInstancesResponse();
     searchInstancesResponse.setTotalRecords(1);
     searchInstancesResponse.setInstances(List.of(new SearchInstance().items(List.of(item1, item2))));
@@ -75,249 +83,131 @@ class AllowedServicePointsApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(asJsonString(searchInstancesResponse), SC_OK)));
 
-    var allowedSpResponseConsortium = new AllowedServicePointsResponse();
-    allowedSpResponseConsortium.setHold(Set.of(
-      buildAllowedServicePoint("SP_consortium_1"),
-      buildAllowedServicePoint("SP_consortium_2")));
-    allowedSpResponseConsortium.setPage(null);
-    allowedSpResponseConsortium.setRecall(Set.of(
-      buildAllowedServicePoint("SP_consortium_3")));
-
     var allowedSpResponseUniversity = new AllowedServicePointsResponse();
     allowedSpResponseUniversity.setHold(null);
     allowedSpResponseUniversity.setPage(null);
     allowedSpResponseUniversity.setRecall(null);
-
-    var allowedSpResponseCollege = new AllowedServicePointsResponse();
-    allowedSpResponseCollege.setHold(null);
-    allowedSpResponseCollege.setPage(null);
-    allowedSpResponseCollege.setRecall(null);
-
-    var allowedSpResponseCollegeWithRouting = new AllowedServicePointsResponse();
-    allowedSpResponseCollegeWithRouting.setHold(null);
-    allowedSpResponseCollegeWithRouting.setPage(Set.of(
-      buildAllowedServicePoint("SP_college_1")));
-    allowedSpResponseCollegeWithRouting.setRecall(null);
-
-    User requester = new User().patronGroup(PATRON_GROUP_ID);
-    wireMockServer.stubFor(get(urlMatching(USER_URL))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(requester), SC_OK)));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(allowedSpResponseConsortium), SC_OK)));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_UNIVERSITY))
       .willReturn(jsonResponse(asJsonString(allowedSpResponseUniversity), SC_OK)));
 
-    var collegeStubMapping = wireMockServer.stubFor(
-      get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-        .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-        .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege), SC_OK)));
+    var allowedSpResponseCollege = new AllowedServicePointsResponse();
+    allowedSpResponseCollege.setHold(Set.of());
+    allowedSpResponseCollege.setPage(Set.of());
+    allowedSpResponseCollege.setRecall(Set.of());
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege), SC_OK)));
 
+    // when - then
     doGet(
       ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&instanceId=%s",
         REQUESTER_ID, INSTANCE_ID))
       .expectStatus().isEqualTo(200)
       .expectBody().json("{}");
 
-    wireMockServer.removeStub(collegeStubMapping);
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .willReturn(jsonResponse(asJsonString(allowedSpResponseCollegeWithRouting),
-        SC_OK)));
+    wireMockServer.verify(getRequestedFor(urlMatching(
+      ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withQueryParam("patronGroupId", equalTo(PATRON_GROUP_ID))
+      .withQueryParam("operation", equalTo("create"))
+      .withQueryParam("instanceId", equalTo(INSTANCE_ID)));
+  }
 
+  @Test
+  void titleLevelCreateReturnsResponsesFromDataTenants() {
+    // given
+    User requester = new User().patronGroup(PATRON_GROUP_ID);
+    wireMockServer.stubFor(get(urlMatching(USER_URL))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .willReturn(jsonResponse(asJsonString(requester), SC_OK)));
+
+    var item1 = new SearchItem().tenantId(TENANT_ID_UNIVERSITY);
+    var item2 = new SearchItem().tenantId(TENANT_ID_COLLEGE);
+    var searchInstancesResponse = new SearchInstancesResponse();
+    searchInstancesResponse.setTotalRecords(1);
+    searchInstancesResponse.setInstances(List.of(new SearchInstance().items(List.of(item1, item2))));
+
+    wireMockServer.stubFor(get(urlMatching(SEARCH_INSTANCES_URL))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .willReturn(jsonResponse(asJsonString(searchInstancesResponse), SC_OK)));
+
+    AllowedServicePointsInner sp1 = buildAllowedServicePoint("SP_college_1");
+    AllowedServicePointsInner sp2 = buildAllowedServicePoint("SP_college_2");
+    AllowedServicePointsInner sp3 = buildAllowedServicePoint("SP_college_3");
+    var allowedSpResponseUniversity = new AllowedServicePointsResponse()
+      .hold(Set.of(sp1))
+      .page(Set.of(sp1))
+      .recall(Set.of(sp2, sp3));
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_UNIVERSITY))
+      .willReturn(jsonResponse(asJsonString(allowedSpResponseUniversity), SC_OK)));
+
+    var allowedSpResponseCollege = new AllowedServicePointsResponse()
+      .hold(Set.of(sp2))
+      .page(Set.of(sp1))
+      .recall(null);
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege), SC_OK)));
+
+    // when - then
+    var allowedSpResponseCombined = new AllowedServicePointsResponse()
+      .hold(Set.of(sp1, sp2))
+      .page(Set.of(sp1))
+      .recall(Set.of(sp2, sp3));
     doGet(
       ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&instanceId=%s",
         REQUESTER_ID, INSTANCE_ID))
       .expectStatus().isEqualTo(200)
-      .expectBody().json(asJsonString(allowedSpResponseConsortium));
+      .expectBody().json(asJsonString(allowedSpResponseCombined));
 
     wireMockServer.verify(getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
+      ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
       .withQueryParam("patronGroupId", equalTo(PATRON_GROUP_ID))
-      .withQueryParam("instanceId", equalTo(INSTANCE_ID))
       .withQueryParam("operation", equalTo("create"))
-      .withQueryParam("useStubItem", equalTo("true")));
+      .withQueryParam("instanceId", equalTo(INSTANCE_ID)));
   }
 
   @Test
-  void allowedServicePointsShouldReturn422WhenParametersAreInvalid() {
-    doGet(ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s", randomId()))
-      .expectStatus().isEqualTo(422);
-  }
+  void itemLevelCreateReturnsResponsesFromDataTenants() {
+    // given
+    User requester = new User().patronGroup(PATRON_GROUP_ID);
+    wireMockServer.stubFor(get(urlMatching(USER_URL))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .willReturn(jsonResponse(asJsonString(requester), SC_OK)));
 
-  @Test
-  void replaceForRequestLinkedToItemWhenPrimaryRequestTypeIsAllowedInBorrowingTenant() {
-    createEcsTlr(true);
+    var searchItemResponse = new SearchItemResponse();
+    searchItemResponse.setTenantId(TENANT_ID_COLLEGE);
+    searchItemResponse.setInstanceId(INSTANCE_ID);
+    searchItemResponse.setId(ITEM_ID);
+    wireMockServer.stubFor(get(urlMatching(SEARCH_ITEM_URL))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .willReturn(jsonResponse(asJsonString(searchItemResponse), SC_OK)));
 
-    var mockAllowedSpResponseFromBorrowingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("borrowing-page")))
-      .hold(Set.of(buildAllowedServicePoint("borrowing-hold")))
-      .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
+    AllowedServicePointsInner sp1 = buildAllowedServicePoint("SP_college_1");
+    AllowedServicePointsInner sp2 = buildAllowedServicePoint("SP_college_2");
+    var allowedSpResponseCollege = new AllowedServicePointsResponse()
+      .hold(Set.of(sp1))
+      .page(Set.of(sp1))
+      .recall(Set.of(sp2));
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege),
+        SC_OK)));
 
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
-
-    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
+    // when - then
+    doGet(
+      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&itemId=%s",
+        REQUESTER_ID, ITEM_ID))
       .expectStatus().isEqualTo(200)
-      .expectBody()
-      .jsonPath("Page").doesNotExist()
-      .jsonPath("Recall").doesNotExist()
-      .jsonPath("Hold").value(hasSize(1))
-      .jsonPath("Hold[0].name").value(is("borrowing-hold"));
-
-    wireMockServer.verify(0, getRequestedFor(urlMatching(REQUEST_STORAGE_URL + ".*")));
-    wireMockServer.verify(0, getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID)));
-  }
-
-  @Test
-  void replaceForRequestLinkedToItemWhenPrimaryRequestTypeIsNotAllowedInBorrowingTenant() {
-    createEcsTlr(true);
-
-    var mockAllowedSpResponseFromBorrowingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("borrowing-page")))
-      .hold(null)
-      .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
-
-    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
-      .expectStatus().isEqualTo(200)
-      .expectBody()
-      .jsonPath("Page").doesNotExist()
-      .jsonPath("Hold").doesNotExist()
-      .jsonPath("Recall").doesNotExist();
-
-    wireMockServer.verify(0, getRequestedFor(urlMatching(REQUEST_STORAGE_URL + ".*")));
-    wireMockServer.verify(0, getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID)));
-  }
-
-  @Test
-  void replaceForRequestNotLinkedToItemWhenSecondaryRequestTypeIsNoLongerAllowedInLendingTenant() {
-    createEcsTlr(false);
-
-    Request secondaryRequest = new Request().id(SECONDARY_REQUEST_ID)
-      .requestType(Request.RequestTypeEnum.PAGE);
-
-    wireMockServer.stubFor(get(urlMatching(REQUEST_STORAGE_URL + "/" + SECONDARY_REQUEST_ID))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(secondaryRequest), SC_OK)));
-
-    var mockAllowedSpResponseFromLendingTenant = new AllowedServicePointsResponse()
-      .page(null)
-      .hold(Set.of(buildAllowedServicePoint("lending-hold")))
-      .recall(Set.of(buildAllowedServicePoint("lending-recall")));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&ecsRequestRouting=true", SECONDARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromLendingTenant), SC_OK)));
-
-    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
-      .expectStatus().isEqualTo(200)
-      .expectBody()
-      .jsonPath("Page").doesNotExist()
-      .jsonPath("Recall").doesNotExist()
-      .jsonPath("Hold").doesNotExist();
-
-    wireMockServer.verify(0, getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID)));
-  }
-
-  @Test
-  void replaceForRequestNotLinkedToItemWhenSecondaryRequestTypeIsAllowedInLendingTenant() {
-    createEcsTlr(false);
-
-    Request secondaryRequest = new Request().id(SECONDARY_REQUEST_ID)
-      .requestType(Request.RequestTypeEnum.PAGE);
-
-    wireMockServer.stubFor(get(urlMatching(REQUEST_STORAGE_URL + "/" + SECONDARY_REQUEST_ID))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(secondaryRequest), SC_OK)));
-
-    var mockAllowedSpResponseFromLendingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("lending-page")))
-      .hold(null)
-      .recall(null);
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&ecsRequestRouting=true", SECONDARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromLendingTenant), SC_OK)));
-
-    var mockAllowedSpResponseFromBorrowingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("borrowing-page")))
-      .hold(Set.of(buildAllowedServicePoint("borrowing-hold")))
-      .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
-
-    wireMockServer.stubFor(
-      get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-        format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
-        .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
-        .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
-
-    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
-      .expectStatus().isEqualTo(200)
-      .expectBody()
-      .jsonPath("Page").doesNotExist()
-      .jsonPath("Recall").doesNotExist()
-      .jsonPath("Hold[0].name").value(is("borrowing-hold"));
+      .expectBody().json(asJsonString(allowedSpResponseCollege));
 
     wireMockServer.verify(getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID)));
-  }
-
-  @Test
-  void replaceForRequestNotLinkedToItemWhenPrimaryRequestTypeIsNotAllowedInBorrowingTenant() {
-    createEcsTlr(false);
-
-    Request secondaryRequest = new Request().id(SECONDARY_REQUEST_ID)
-      .requestType(Request.RequestTypeEnum.PAGE);
-
-    wireMockServer.stubFor(get(urlMatching(REQUEST_STORAGE_URL + "/" + SECONDARY_REQUEST_ID))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(secondaryRequest), SC_OK)));
-
-    var mockAllowedSpResponseFromLendingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("lending-page")))
-      .hold(null)
-      .recall(null);
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&ecsRequestRouting=true", SECONDARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromLendingTenant), SC_OK)));
-
-    var mockAllowedSpResponseFromBorrowingTenant = new AllowedServicePointsResponse()
-      .page(Set.of(buildAllowedServicePoint("borrowing-page")))
-      .hold(null)
-      .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=true", PRIMARY_REQUEST_ID)))
-      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
-      .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
-
-    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
-      .expectStatus().isEqualTo(200)
-      .expectBody()
-      .jsonPath("Page").doesNotExist()
-      .jsonPath("Recall").doesNotExist()
-      .jsonPath("Hold").doesNotExist();
+      ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
+      .withQueryParam("patronGroupId", equalTo(PATRON_GROUP_ID))
+      .withQueryParam("operation", equalTo("create"))
+      .withQueryParam("itemId", equalTo(ITEM_ID)));
   }
 
   @Test
@@ -336,67 +226,43 @@ class AllowedServicePointsApiTest extends BaseIT {
       .expectStatus().isEqualTo(500);
   }
 
-  @Test
-  void allowedSpWithItemLevelReturnsResultSpInResponsesFromDataTenant() {
-    var searchItemResponse = new SearchItemResponse();
-    searchItemResponse.setTenantId(TENANT_ID_COLLEGE);
-    searchItemResponse.setInstanceId(INSTANCE_ID);
-    searchItemResponse.setId(ITEM_ID);
+  @ParameterizedTest
+  @EnumSource(Request.RequestTypeEnum.class)
+  void replaceForRequestNotLinkedToItem(Request.RequestTypeEnum secondaryRequestType) {
+    // given
+    createEcsTlr(false);
 
-    wireMockServer.stubFor(get(urlMatching(SEARCH_ITEM_URL))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(searchItemResponse), SC_OK)));
+    Request secondaryRequest = new Request().id(SECONDARY_REQUEST_ID)
+      .requestType(secondaryRequestType);
 
-    var allowedSpResponseConsortium = new AllowedServicePointsResponse();
-    allowedSpResponseConsortium.setHold(Set.of(
-      buildAllowedServicePoint("SP_consortium_1"),
-      buildAllowedServicePoint("SP_consortium_2")));
-    allowedSpResponseConsortium.setPage(null);
-    allowedSpResponseConsortium.setRecall(Set.of(
-      buildAllowedServicePoint("SP_consortium_3")));
+    wireMockServer.stubFor(get(urlMatching(REQUEST_STORAGE_URL + "/" + SECONDARY_REQUEST_ID))
+      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
+      .willReturn(jsonResponse(asJsonString(secondaryRequest), SC_OK)));
 
-    var allowedSpResponseCollege = new AllowedServicePointsResponse();
-    allowedSpResponseCollege.setHold(Set.of(
-      buildAllowedServicePoint("SP_college_1")));
-    allowedSpResponseCollege.setPage(null);
-    allowedSpResponseCollege.setRecall(Set.of(
-      buildAllowedServicePoint("SP_college_2")));
+    Set<AllowedServicePointsInner> servicePoints = Set.of(
+      buildAllowedServicePoint("SP1"),
+      buildAllowedServicePoint("SP2")
+    );
+    var allowedSpResponseSecondaryRequestTenant = new AllowedServicePointsResponse();
+    switch (secondaryRequestType) {
+      case PAGE -> allowedSpResponseSecondaryRequestTenant.page(servicePoints);
+      case HOLD -> allowedSpResponseSecondaryRequestTenant.hold(servicePoints);
+      case RECALL -> allowedSpResponseSecondaryRequestTenant.recall(servicePoints);
+    }
 
-    User requester = new User().patronGroup(PATRON_GROUP_ID);
-    wireMockServer.stubFor(get(urlMatching(USER_URL))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(requester), SC_OK)));
+    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
+      String.format("\\?operation=replace&requestId=%s", SECONDARY_REQUEST_ID)))
+      .withHeader(HEADER_TENANT, equalTo(LENDING_TENANT_ID))
+      .willReturn(jsonResponse(asJsonString(allowedSpResponseSecondaryRequestTenant), SC_OK)));
 
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(asJsonString(allowedSpResponseConsortium), SC_OK)));
-
-    wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .willReturn(jsonResponse(asJsonString(allowedSpResponseCollege),
-        SC_OK)));
-
-    doGet(
-      ALLOWED_SERVICE_POINTS_URL + format("?operation=create&requesterId=%s&itemId=%s",
-        REQUESTER_ID, ITEM_ID))
+    // then - then
+    doGet(ALLOWED_SERVICE_POINTS_FOR_REPLACE_URL)
       .expectStatus().isEqualTo(200)
-      .expectBody().json(asJsonString(allowedSpResponseConsortium));
+      .expectBody().json(asJsonString(allowedSpResponseSecondaryRequestTenant));
 
-    wireMockServer.verify(getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE))
-      .withQueryParam("patronGroupId", equalTo(PATRON_GROUP_ID))
-      .withQueryParam("operation", equalTo("create"))
-      .withQueryParam("ecsRequestRouting", equalTo("true"))
-      .withQueryParam("itemId", equalTo(ITEM_ID)));
-
-    wireMockServer.verify(getRequestedFor(urlMatching(
-      ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL_PATTERN))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withQueryParam("patronGroupId", equalTo(PATRON_GROUP_ID))
-      .withQueryParam("instanceId", equalTo(INSTANCE_ID))
-      .withQueryParam("operation", equalTo("create"))
-      .withQueryParam("useStubItem", equalTo("true")));
+    wireMockServer.verify(0, getRequestedFor(urlMatching(
+      ALLOWED_SPS_MOD_CIRCULATION_URL_PATTERN))
+      .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID)));
   }
 
   private AllowedServicePointsInner buildAllowedServicePoint(String name) {

--- a/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
+++ b/src/test/java/org/folio/api/AllowedServicePointsApiTest.java
@@ -218,7 +218,7 @@ class AllowedServicePointsApiTest extends BaseIT {
       .recall(Set.of(buildAllowedServicePoint("borrowing-recall")));
 
     wireMockServer.stubFor(get(urlMatching(ALLOWED_SERVICE_POINTS_MOD_CIRCULATION_URL +
-      String.format("\\?operation=replace&requestId=%s&useStubItem=false", PRIMARY_REQUEST_ID)))
+      String.format("\\?operation=replace&requestId=%s", PRIMARY_REQUEST_ID)))
       .withHeader(HEADER_TENANT, equalTo(BORROWING_TENANT_ID))
       .willReturn(jsonResponse(asJsonString(mockAllowedSpResponseFromBorrowingTenant), SC_OK)));
 


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODTLR-68

## Approach
1. Updated existing implementation to remove checks based on routing service points.
2. Used approach to fetch all valid service points in corresponding tenants.

#### TODOS and Open Questions

## Learning
