### PR TITLE
MODTLR-116 Copy Secure Patron name when cloning users

### DIFF
--- a/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/UserCloningServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.service.impl;
 
 import org.folio.domain.dto.User;
+import org.folio.domain.dto.UserPersonal;
 import org.folio.domain.dto.UserType;
 import org.folio.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,17 @@ public class UserCloningServiceImpl extends CloningServiceImpl<User> {
       .type(UserType.SHADOW.getValue())
       .barcode(original.getBarcode())
       .active(true);
+
+    // TODO: Remove hardcoded Secure Patron name. mod-tlr shouldn't know about secure requests,
+    //  but there should be a mechanism to let it know that the user's name should also be copied
+    String firstName = original.getPersonal().getFirstName();
+    String lastName = original.getPersonal().getLastName();
+    if ("Secure".equals(firstName) && "Patron".equals(lastName)) {
+      clone.personal(new UserPersonal()
+        .firstName(firstName)
+        .lastName(lastName));
+    }
+
     log.debug("buildClone:: result: {}", () -> clone);
     return clone;
   }

--- a/src/test/java/org/folio/service/UserCloningServiceTest.java
+++ b/src/test/java/org/folio/service/UserCloningServiceTest.java
@@ -1,0 +1,57 @@
+package org.folio.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.folio.domain.dto.User;
+import org.folio.domain.dto.UserPersonal;
+import org.folio.service.impl.UserCloningServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import feign.FeignException;
+import feign.Request;
+
+@ExtendWith(MockitoExtension.class)
+public class UserCloningServiceTest {
+
+  @Spy
+  private UserService userService;
+
+  private CloningService<User> userCloningService;
+
+  @Captor
+  ArgumentCaptor<User> userCaptor;
+
+  @Test
+  void securePatronNameShouldBeCopied() {
+    userCloningService = new UserCloningServiceImpl(userService);
+
+    doThrow(new FeignException.NotFound(null, Request.create(Request.HttpMethod.GET, "", Map.of(),
+      Request.Body.create(""), null), null, null))
+      .when(userService)
+      .find(any(String.class));
+    when(userService.create(any(User.class))).thenReturn(null);
+
+    userCloningService.clone(new User()
+      .id(UUID.randomUUID().toString())
+      .personal(new UserPersonal()
+        .firstName("Secure")
+        .lastName("Patron")));
+
+    verify(userService).create(userCaptor.capture());
+
+    assertEquals("Secure", userCaptor.getValue().getPersonal().getFirstName());
+    assertEquals("Patron", userCaptor.getValue().getPersonal().getLastName());
+  }
+}

--- a/src/test/java/org/folio/service/UserCloningServiceTest.java
+++ b/src/test/java/org/folio/service/UserCloningServiceTest.java
@@ -23,7 +23,7 @@ import feign.FeignException;
 import feign.Request;
 
 @ExtendWith(MockitoExtension.class)
-public class UserCloningServiceTest {
+class UserCloningServiceTest {
 
   @Spy
   private UserService userService;


### PR DESCRIPTION
## Purpose
MODTLR-116 

## Approach
If patron name is Secure Patron, keep it when cloning the requester to other tenants
