### PR TITLE
MODTLR-125: Spring Boot 3.3.7, folio-spring 8.2.2 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.0</version>
+    <version>3.3.7</version>
     <relativePath/>
   </parent>
   <groupId>org.folio</groupId>
@@ -32,7 +32,7 @@
     <argLine />
 
     <!-- runtime dependencies -->
-    <folio-spring-support.version>8.2.0</folio-spring-support.version>
+    <folio-spring-support.version>8.2.2</folio-spring-support.version>
     <openapi-generator.version>7.1.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODTLR-125

## Purpose
Fix security vulnerabilities in dependencies.

## Approach
Upgrade Spring Boot from 3.3.0 to 3.3.7.

Upgrade folio-spring-* from 8.2.0 to 8.2.2.

These upgrades indirectly upgrade kafka-clients from 3.7.0 to 3.7.2 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-56128 Incorrect Implementation of Authentication Algorithm

These upgrades indirectly upgrade tomcat-embed-core from 10.1.24 to 10.1.34 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38286 Allocation of Resources Without Limits or Throttling
* https://www.cve.org/CVERecord?id=CVE-2024-34750 Insufficient Session Expiration

These upgrades indirectly upgrade spring-security-crypto from 6.3.0 to 6.3.6 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38827 Authorization Bypass