### PR TITLE
MODTLR-139 Add patronComments mapping to primary request

### DIFF
--- a/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/EcsTlrServiceImpl.java
@@ -163,7 +163,8 @@ public class EcsTlrServiceImpl implements EcsTlrService {
       .requestType(secondaryRequest.getRequestType())
       .ecsRequestPhase(ecsRequestPhase)
       .fulfillmentPreference(secondaryRequest.getFulfillmentPreference())
-      .pickupServicePointId(secondaryRequest.getPickupServicePointId());
+      .pickupServicePointId(secondaryRequest.getPickupServicePointId())
+      .patronComments(secondaryRequest.getPatronComments());
   }
 
   private Request buildSecondaryRequest(EcsTlrEntity ecsTlr) {

--- a/src/test/java/org/folio/api/EcsTlrApiTest.java
+++ b/src/test/java/org/folio/api/EcsTlrApiTest.java
@@ -542,7 +542,8 @@ class EcsTlrApiTest extends BaseIT {
       .requestType(secondaryRequest.getRequestType())
       .ecsRequestPhase(ecsRequestPhase)
       .fulfillmentPreference(secondaryRequest.getFulfillmentPreference())
-      .pickupServicePointId(secondaryRequest.getPickupServicePointId());
+      .pickupServicePointId(secondaryRequest.getPickupServicePointId())
+      .patronComments(secondaryRequest.getPatronComments());
   }
 
   private static SearchItem buildItem(String id, String tenantId, String status) {


### PR DESCRIPTION
## Purpose
Problem: The Patron Comments for ECS requests do not display in Primary requests. They do display in Secondary requests in the Requests app

Resolves: [MODTLR-139](https://folio-org.atlassian.net/browse/MODTLR-139)