### PR TITLE
Add workflow_dispatch to api workflows

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -33,6 +33,7 @@ on:
     paths:
       - 'src/main/resources/swagger.api/**'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   api-doc:

--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -32,6 +32,7 @@ on:
     branches: [ main, master ]
     paths:
       - 'src/main/resources/swagger.api/**'
+      - 'descriptors/ModuleDescriptor-template.json'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -33,6 +33,7 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-lint:

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -23,6 +23,7 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-schema-lint:


### PR DESCRIPTION
## Purpose
Add workflow_dispatch, needed for https://folio-org.atlassian.net/browse/FOLIO-4183

This keeps the *.yml files in sync with the templates: https://github.com/folio-org/.github/tree/master/workflow-templates

## Approach
Update the .github/workflows/*.yml files.