### PR TITLE
MODTLR-152 Add force loan policy support during check-out

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -412,6 +412,8 @@
         "circulation-storage.requests.item.get",
         "circulation-storage.requests.collection.get",
         "circulation-storage.requests.item.put",
+        "circulation-storage.loan-policies.collection.get",
+        "circulation-storage.loan-policies.item.get",
         "inventory-storage.service-points.item.get",
         "inventory-storage.service-points.collection.get",
         "inventory-storage.service-points.item.post",
@@ -445,7 +447,8 @@
         "mod-settings.entries.item.get",
         "mod-settings.entries.collection.get",
         "mod-settings.global.read.circulation",
-        "consortia.sharing-instances.item.post"
+        "consortia.sharing-instances.item.post",
+        "circulation.check-out-by-barcode-dry-run.post"
       ]
     }
   },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -174,7 +174,11 @@
           "permissionsRequired": ["tlr.loans.check-out-by-barcode.execute"],
           "modulePermissions": [
             "consortium-search.items.batch.collection.get",
-            "circulation.check-out-by-barcode.post"
+            "circulation.check-out-by-barcode.post",
+            "circulation.check-out-by-barcode-dry-run.post",
+            "circulation-storage.loan-policies.collection.get",
+            "circulation-storage.loan-policies.item.get",
+            "circulation-storage.loan-policies.item.post"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -448,7 +448,8 @@
         "mod-settings.entries.collection.get",
         "mod-settings.global.read.circulation",
         "consortia.sharing-instances.item.post",
-        "circulation.check-out-by-barcode-dry-run.post"
+        "circulation.check-out-by-barcode-dry-run.post",
+        "configuration.entries.collection.get"
       ]
     }
   },

--- a/src/main/java/org/folio/client/feign/CheckOutClient.java
+++ b/src/main/java/org/folio/client/feign/CheckOutClient.java
@@ -1,6 +1,8 @@
 package org.folio.client.feign;
 
 import org.folio.client.feign.config.ErrorForwardingFeignClientConfiguration;
+import org.folio.domain.dto.CheckOutDryRunRequest;
+import org.folio.domain.dto.CheckOutDryRunResponse;
 import org.folio.domain.dto.CheckOutRequest;
 import org.folio.domain.dto.CheckOutResponse;
 import org.folio.spring.config.FeignClientConfiguration;
@@ -14,4 +16,7 @@ public interface CheckOutClient {
 
   @PostMapping("/check-out-by-barcode")
   CheckOutResponse checkOut(@RequestBody CheckOutRequest request);
+
+  @PostMapping("/check-out-by-barcode-dry-run")
+  CheckOutDryRunResponse checkOutDryRun(@RequestBody CheckOutDryRunRequest request);
 }

--- a/src/main/java/org/folio/client/feign/CirculationClient.java
+++ b/src/main/java/org/folio/client/feign/CirculationClient.java
@@ -36,7 +36,4 @@ public interface CirculationClient {
   AllowedServicePointsResponse allowedServicePoints(
     @RequestParam("operation") String operation,
     @RequestParam("requestId") String requestId);
-
-  @PostMapping("/check-out-by-barcode")
-  CheckOutResponse checkOut(@RequestBody CheckOutRequest request);
 }

--- a/src/main/java/org/folio/client/feign/CirculationClient.java
+++ b/src/main/java/org/folio/client/feign/CirculationClient.java
@@ -1,14 +1,11 @@
 package org.folio.client.feign;
 
 import org.folio.domain.dto.AllowedServicePointsResponse;
-import org.folio.domain.dto.CheckOutRequest;
-import org.folio.domain.dto.CheckOutResponse;
 import org.folio.domain.dto.Request;
 import org.folio.spring.config.FeignClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "circulation", url = "circulation", configuration = FeignClientConfiguration.class)

--- a/src/main/java/org/folio/client/feign/LoanPolicyClient.java
+++ b/src/main/java/org/folio/client/feign/LoanPolicyClient.java
@@ -1,0 +1,22 @@
+package org.folio.client.feign;
+
+import org.folio.client.feign.config.ErrorForwardingFeignClientConfiguration;
+import org.folio.domain.dto.LoanPolicy;
+import org.folio.spring.config.FeignClientConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "items", url = "loan-policy-storage/loan-policies",
+  configuration = { FeignClientConfiguration.class, ErrorForwardingFeignClientConfiguration.class })
+public interface LoanPolicyClient extends GetByQueryClient<LoanPolicy> {
+
+  @GetMapping("/{id}")
+  LoanPolicy get(@PathVariable String id);
+
+  @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+  LoanPolicy post(@RequestBody LoanPolicy loanPolicy);
+}

--- a/src/main/java/org/folio/client/feign/LoanPolicyClient.java
+++ b/src/main/java/org/folio/client/feign/LoanPolicyClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "items", url = "loan-policy-storage/loan-policies",
+@FeignClient(name = "loan-policies", url = "loan-policy-storage/loan-policies",
   configuration = { FeignClientConfiguration.class, ErrorForwardingFeignClientConfiguration.class })
 public interface LoanPolicyClient extends GetByQueryClient<LoanPolicy> {
 

--- a/src/main/java/org/folio/client/feign/LoanPolicyClient.java
+++ b/src/main/java/org/folio/client/feign/LoanPolicyClient.java
@@ -1,6 +1,5 @@
 package org.folio.client.feign;
 
-import org.folio.client.feign.config.ErrorForwardingFeignClientConfiguration;
 import org.folio.domain.dto.LoanPolicy;
 import org.folio.spring.config.FeignClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -11,8 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "loan-policies", url = "loan-policy-storage/loan-policies",
-  configuration = { FeignClientConfiguration.class, ErrorForwardingFeignClientConfiguration.class })
-public interface LoanPolicyClient extends GetByQueryClient<LoanPolicy> {
+  configuration = FeignClientConfiguration.class)
+public interface LoanPolicyClient {
 
   @GetMapping("/{id}")
   LoanPolicy get(@PathVariable String id);

--- a/src/main/java/org/folio/domain/mapper/CheckOutDryRunRequestMapper.java
+++ b/src/main/java/org/folio/domain/mapper/CheckOutDryRunRequestMapper.java
@@ -1,0 +1,12 @@
+package org.folio.domain.mapper;
+
+import org.folio.domain.dto.CheckOutDryRunRequest;
+import org.folio.domain.dto.CheckOutRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueCheckStrategy;
+
+@Mapper(componentModel = "spring", nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+public interface CheckOutDryRunRequestMapper {
+
+  CheckOutDryRunRequest mapCheckOutRequestToCheckOutDryRunRequest(CheckOutRequest checkOutRequest);
+}

--- a/src/main/java/org/folio/service/LoanPolicyService.java
+++ b/src/main/java/org/folio/service/LoanPolicyService.java
@@ -1,0 +1,8 @@
+package org.folio.service;
+
+import org.folio.domain.dto.LoanPolicy;
+
+public interface LoanPolicyService {
+  LoanPolicy find(String loanPolicyId);
+  LoanPolicy create(LoanPolicy loanPolicy);
+}

--- a/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
@@ -24,7 +24,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class CheckOutServiceImpl implements CheckOutService {
 
-  private static final String LOAN_POLICY_PREFIX = "CLONE_";
+  private static final String LOAN_POLICY_PREFIX = "CLONE_%s";
   private final SearchService searchService;
   private final CheckOutClient checkOutClient;
   private final LoanPolicyClient loanPolicyClient;
@@ -41,8 +41,7 @@ public class CheckOutServiceImpl implements CheckOutService {
 
     var loanPolicy = executionService.executeSystemUserScoped(itemTenant,
       () -> retrieveLoanPolicy(checkOutRequest));
-    loanPolicyClient.post(loanPolicy.name(format(LOAN_POLICY_PREFIX + "%s",
-      loanPolicy.getName())));
+    loanPolicyClient.post(loanPolicy.name(format(LOAN_POLICY_PREFIX, loanPolicy.getName())));
 
     var checkOutResponse = checkOutClient.checkOut(checkOutRequest.forceLoanPolicyId(
       UUID.fromString(loanPolicy.getId())));

--- a/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
@@ -1,11 +1,19 @@
 package org.folio.service.impl;
 
+import static java.lang.String.format;
+
+import java.util.UUID;
+
 import org.folio.client.feign.CheckOutClient;
+import org.folio.client.feign.LoanPolicyClient;
 import org.folio.domain.dto.CheckOutRequest;
 import org.folio.domain.dto.CheckOutResponse;
 import org.folio.domain.dto.ConsortiumItem;
+import org.folio.domain.dto.LoanPolicy;
+import org.folio.domain.mapper.CheckOutDryRunRequestMapper;
 import org.folio.service.CheckOutService;
 import org.folio.service.SearchService;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -16,19 +24,41 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class CheckOutServiceImpl implements CheckOutService {
 
+  private static final String LOAN_POLICY_PREFIX = "CLONE_";
   private final SearchService searchService;
   private final CheckOutClient checkOutClient;
+  private final LoanPolicyClient loanPolicyClient;
+  private final CheckOutDryRunRequestMapper checkOutDryRunRequestMapper;
+  private final SystemUserScopedExecutionService executionService;
+
 
   @Override
   public CheckOutResponse checkOut(CheckOutRequest checkOutRequest) {
     log.info("checkOut:: checking out item {} to user {}", checkOutRequest.getItemBarcode(),
       checkOutRequest.getUserBarcode());
-    String itemTenant = findItemTenant(checkOutRequest.getItemBarcode());
+    var itemTenant = findItemTenant(checkOutRequest.getItemBarcode());
+    log.info("checkOut:: itemTenant: {} ", itemTenant);
 
-    CheckOutResponse checkOutResponse = checkOutClient.checkOut(checkOutRequest);
+    var loanPolicy = executionService.executeSystemUserScoped(itemTenant,
+      () -> retrieveLoanPolicy(checkOutRequest));
+    loanPolicyClient.post(loanPolicy.name(format(LOAN_POLICY_PREFIX + "%s",
+      loanPolicy.getName())));
+
+    var checkOutResponse = checkOutClient.checkOut(checkOutRequest.forceLoanPolicyId(
+      UUID.fromString(loanPolicy.getId())));
     log.info("checkOut:: item checked out");
 
     return checkOutResponse;
+  }
+
+  private LoanPolicy retrieveLoanPolicy(CheckOutRequest checkOutRequest) {
+    var checkOutDryRunResponse = checkOutClient.checkOutDryRun(checkOutDryRunRequestMapper
+      .mapCheckOutRequestToCheckOutDryRunRequest(checkOutRequest));
+    log.info("retrieveLoanPolicy:: checkOutDryRunResponse: {}", checkOutDryRunResponse);
+    var loanPolicy = loanPolicyClient.get(checkOutDryRunResponse.getLoanPolicyId());
+    log.debug("retrieveLoanPolicy:: loanPolicy: {}", loanPolicy);
+
+    return loanPolicy;
   }
 
   private String findItemTenant(String itemBarcode) {

--- a/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/CheckOutServiceImpl.java
@@ -1,7 +1,5 @@
 package org.folio.service.impl;
 
-import static java.lang.String.format;
-
 import java.util.UUID;
 
 import org.folio.client.feign.CheckOutClient;
@@ -12,6 +10,7 @@ import org.folio.domain.dto.ConsortiumItem;
 import org.folio.domain.dto.LoanPolicy;
 import org.folio.domain.mapper.CheckOutDryRunRequestMapper;
 import org.folio.service.CheckOutService;
+import org.folio.service.CloningService;
 import org.folio.service.SearchService;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.stereotype.Service;
@@ -24,8 +23,8 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class CheckOutServiceImpl implements CheckOutService {
 
-  private static final String LOAN_POLICY_PREFIX = "CLONE_%s";
   private final SearchService searchService;
+  private final CloningService<LoanPolicy> loanPolicyCloningService;
   private final CheckOutClient checkOutClient;
   private final LoanPolicyClient loanPolicyClient;
   private final CheckOutDryRunRequestMapper checkOutDryRunRequestMapper;
@@ -41,7 +40,7 @@ public class CheckOutServiceImpl implements CheckOutService {
 
     var loanPolicy = executionService.executeSystemUserScoped(itemTenant,
       () -> retrieveLoanPolicy(checkOutRequest));
-    loanPolicyClient.post(loanPolicy.name(format(LOAN_POLICY_PREFIX, loanPolicy.getName())));
+    loanPolicyCloningService.clone(loanPolicy);
 
     var checkOutResponse = checkOutClient.checkOut(checkOutRequest.forceLoanPolicyId(
       UUID.fromString(loanPolicy.getId())));

--- a/src/main/java/org/folio/service/impl/LoanPolicyCloningServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/LoanPolicyCloningServiceImpl.java
@@ -1,0 +1,36 @@
+package org.folio.service.impl;
+
+import org.folio.domain.dto.LoanPolicy;
+import org.folio.service.LoanPolicyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Service
+public class LoanPolicyCloningServiceImpl extends CloningServiceImpl<LoanPolicy> {
+  private static final String COPY_LOAN_POLICY_PREFIX = "COPY_OF_%s";
+  private final LoanPolicyService loanPolicyService;
+
+  public LoanPolicyCloningServiceImpl(@Autowired LoanPolicyService loanPolicyService) {
+
+    super(LoanPolicy::getId);
+    this.loanPolicyService = loanPolicyService;
+  }
+
+  @Override
+  protected LoanPolicy find(String loanPolicyId) {
+    return loanPolicyService.find(loanPolicyId);
+  }
+
+  @Override
+  protected LoanPolicy create(LoanPolicy clone) {
+    return loanPolicyService.create(clone);
+  }
+
+  @Override
+  protected LoanPolicy buildClone(LoanPolicy loanPolicy) {
+    return loanPolicy.name(String.format(COPY_LOAN_POLICY_PREFIX, loanPolicy.getName()));
+  }
+}

--- a/src/main/java/org/folio/service/impl/LoanPolicyServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/LoanPolicyServiceImpl.java
@@ -1,0 +1,29 @@
+package org.folio.service.impl;
+
+import org.folio.client.feign.LoanPolicyClient;
+import org.folio.domain.dto.LoanPolicy;
+import org.folio.service.LoanPolicyService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class LoanPolicyServiceImpl implements LoanPolicyService {
+
+  private final LoanPolicyClient loanPolicyClient;
+
+  @Override
+  public LoanPolicy find(String loanPolicyId) {
+    log.info("find:: looking up loanPolicy {}", loanPolicyId);
+    return loanPolicyClient.get(loanPolicyId);
+  }
+
+  @Override
+  public LoanPolicy create(LoanPolicy loanPolicy) {
+    log.info("create:: creating loanPolicy {}", loanPolicy.getId());
+    return loanPolicyClient.post(loanPolicy);
+  }
+}

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -47,4 +47,5 @@ inventory-storage.location-units.campuses.collection.get
 inventory-storage.location-units.institutions.item.get
 inventory-storage.location-units.institutions.collection.get
 circulation.rules.request-policy.get
-consortia.sharing-instances.item.post
+consortia.sharing-instances.item.post,
+circulation.check-out-by-barcode-dry-run.post

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -49,3 +49,4 @@ inventory-storage.location-units.institutions.collection.get
 circulation.rules.request-policy.get
 consortia.sharing-instances.item.post
 circulation.check-out-by-barcode-dry-run.post
+configuration.entries.collection.get

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -47,5 +47,5 @@ inventory-storage.location-units.campuses.collection.get
 inventory-storage.location-units.institutions.item.get
 inventory-storage.location-units.institutions.collection.get
 circulation.rules.request-policy.get
-consortia.sharing-instances.item.post,
+consortia.sharing-instances.item.post
 circulation.check-out-by-barcode-dry-run.post

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -15,6 +15,8 @@ circulation.requests.queue.instance-reorder.collection.post
 circulation-storage.requests.item.get
 circulation-storage.requests.collection.get
 circulation-storage.requests.item.put
+circulation-storage.loan-policies.collection.get
+circulation-storage.loan-policies.item.get
 inventory-storage.service-points.item.get
 inventory-storage.service-points.collection.get
 inventory-storage.service-points.item.post

--- a/src/main/resources/swagger.api/ecs-loans.yaml
+++ b/src/main/resources/swagger.api/ecs-loans.yaml
@@ -30,6 +30,12 @@ components:
   schemas:
     check-out-request:
       $ref: 'schemas/circulation/check-out-request.yaml'
+    check-out-dry-run-request:
+      $ref: 'schemas/circulation/check-out-dry-run-request.yaml'
+    check-out-dry-run-response:
+      $ref: 'schemas/circulation/check-out-dry-run-response.yaml'
+    loan-policy:
+      $ref: 'schemas/circulation-storage/loan-policy.json'
     errorResponse:
       $ref: 'schemas/errors.json'
     consortiumItems:

--- a/src/main/resources/swagger.api/schemas/circulation-storage/loan-policy.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/loan-policy.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Rules governing loans",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "description": "The name of the policy.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the loan policy",
+      "type": "string"
+    },
+    "loanable": {
+      "description": "Flag that indicates whether this policy allows loans",
+      "type": "boolean"
+    },
+    "loansPolicy": {
+      "type": "object",
+      "description": "Settings for loans",
+      "additionalProperties": true,
+      "properties": {
+        "profileId": {
+          "type": "string",
+          "description": "Loan profile"
+        },
+        "period": {
+          "type": "object",
+          "$ref": "period.json",
+          "description": "Loan period"
+        },
+        "closedLibraryDueDateManagementId": {
+          "type": "string",
+          "description": "Closed library due date management"
+        },
+        "gracePeriod": {
+          "type": "object",
+          "$ref": "period.json",
+          "description": "Grace period"
+        },
+        "openingTimeOffset": {
+          "type": "object",
+          "$ref": "period.json",
+          "description": "Opening offset time period"
+        },
+        "fixedDueDateScheduleId": {
+          "type": "string",
+          "description": "Fixed due date schedule (due date limit)"
+        },
+        "itemLimit": {
+          "type": "integer",
+          "description": "Number of items allowed",
+          "minimum": 1,
+          "maximum": 9999
+        }
+      }
+    },
+    "renewable": {
+      "type": "boolean",
+      "description": "Is item renewable"
+    },
+    "renewalsPolicy": {
+      "type": "object",
+      "description": "Settings for renewals",
+      "properties": {
+        "unlimited": {
+          "type": "boolean",
+          "description": "Unlimited renewals"
+        },
+        "numberAllowed": {
+          "type": "number",
+          "description": "Number of renewals allowed"
+        },
+        "renewFromId": {
+          "type": "string",
+          "description": "Renew from date"
+        },
+        "differentPeriod": {
+          "type": "boolean",
+          "description": "Renewal period different from original loan"
+        },
+        "period": {
+          "type": "object",
+          "$ref": "period.json",
+          "description": "Alternate loan period for renewals"
+        },
+        "alternateFixedDueDateScheduleId": {
+          "type": "string",
+          "description": "Alternate fixed due date schedule (due date limit) for renewals"
+        }
+      }
+    },
+    "requestManagement": {
+      "type": "object",
+      "description": "Settings for various request types",
+      "additionalProperties": true,
+      "properties": {
+        "recalls": {
+          "type": "object",
+          "description": "Settings for recall requests",
+          "additionalProperties": true,
+          "properties": {
+            "alternateGracePeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate grace period for recalled items"
+            },
+            "minimumGuaranteedLoanPeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Minimum guaranteed loan period"
+            },
+            "recallReturnInterval": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Recall return interval"
+            },
+            "allowRecallsToExtendOverdueLoans": {
+              "type": "boolean",
+              "description": "Whether recalls are allowed to extend overdue loans",
+              "default": false
+            },
+            "alternateRecallReturnInterval": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate recall return interval for overdue loans"
+            }
+          }
+        },
+        "holds": {
+          "type": "object",
+          "description": "Settings for hold requests",
+          "additionalProperties": true,
+          "properties": {
+            "alternateCheckoutLoanPeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate loan period at checkout for items with active, pending hold request"
+            },
+            "renewItemsWithRequest": {
+              "type": "boolean",
+              "description": "Allow renewal of items with active, pending hold request"
+            },
+            "alternateRenewalLoanPeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate loan period at renewal for items with active, pending hold request"
+            }
+          }
+        },
+        "pages": {
+          "type": "object",
+          "description": "Settings for page requests",
+          "additionalProperties": true,
+          "properties": {
+            "alternateCheckoutLoanPeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate loan period at checkout for items with active, pending page request"
+            },
+            "renewItemsWithRequest": {
+              "type": "boolean",
+              "description": "Allow renewal of items with active, pending page request"
+            },
+            "alternateRenewalLoanPeriod": {
+              "type": "object",
+              "$ref": "period.json",
+              "description": "Alternate loan period at renewal for items with active, pending page request"
+            }
+          }
+        }
+      }
+    },
+    "metadata": {
+      "$ref": "../metadata.json",
+      "readonly": true
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "name",
+    "loanable",
+    "renewable"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/circulation-storage/loan-policy.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/loan-policy.json
@@ -179,10 +179,5 @@
       "readonly": true
     }
   },
-  "additionalProperties": true,
-  "required": [
-    "name",
-    "loanable",
-    "renewable"
-  ]
+  "additionalProperties": true
 }

--- a/src/main/resources/swagger.api/schemas/circulation-storage/period.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/period.json
@@ -24,5 +24,5 @@
     "duration",
     "intervalId"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/src/main/resources/swagger.api/schemas/circulation-storage/period.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/period.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Time interval defined by its duration",
+  "properties": {
+    "duration": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Duration of the period, number of times the interval repeats"
+    },
+    "intervalId": {
+      "type": "string",
+      "description": "Interval for the period, e.g. hours, days or weeks",
+      "enum":[
+        "Minutes",
+        "Hours",
+        "Days",
+        "Weeks",
+        "Months"
+      ]
+    }
+  },
+  "required": [
+    "duration",
+    "intervalId"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/swagger.api/schemas/circulation-storage/period.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/period.json
@@ -20,9 +20,5 @@
       ]
     }
   },
-  "required": [
-    "duration",
-    "intervalId"
-  ],
   "additionalProperties": true
 }

--- a/src/main/resources/swagger.api/schemas/circulation/check-out-dry-run-request.yaml
+++ b/src/main/resources/swagger.api/schemas/circulation/check-out-dry-run-request.yaml
@@ -1,0 +1,16 @@
+type: object
+description: Request to dry run check out an item to a loanee using barcodes
+properties:
+  itemBarcode:
+    description: Barcode of the item to be lent to the patron
+    type: string
+  userBarcode:
+    description: Barcode of the user (representing the patron) the item is to be lent to
+    type: string
+  proxyUserBarcode:
+    description: Barcode of the user representing a proxy for the patron
+    type: string
+additionalProperties: true
+required:
+  - itemBarcode
+  - userBarcode

--- a/src/main/resources/swagger.api/schemas/circulation/check-out-dry-run-response.yaml
+++ b/src/main/resources/swagger.api/schemas/circulation/check-out-dry-run-response.yaml
@@ -1,0 +1,16 @@
+type: object
+description: Check out dry run response
+properties:
+  loanPolicyId:
+    description: ID of the loan policy determined by the circulation rules
+    type: string
+  overdueFinePolicyId:
+    description: ID of the overdue fine policy determined by the circulation rules
+    type: string
+  lostItemPolicyId:
+    description: ID of the lost item policy determined by the circulation rules
+    type: string
+  patronNoticePolicyId:
+    description: ID of the patron notice policy determined by the circulation rules
+    type: string
+additionalProperties: true

--- a/src/main/resources/swagger.api/schemas/circulation/check-out-request.yaml
+++ b/src/main/resources/swagger.api/schemas/circulation/check-out-request.yaml
@@ -18,6 +18,10 @@ properties:
     description: Service point where the item has been checked out
     type: string
     format: uuid
+  forceLoanPolicyId:
+    description: Force loan policy ID
+    type: string
+    format: uuid
   overrideBlocks:
     description: Blocks to override
     type: object

--- a/src/test/java/org/folio/api/CheckOutApiTest.java
+++ b/src/test/java/org/folio/api/CheckOutApiTest.java
@@ -74,6 +74,7 @@ class CheckOutApiTest extends BaseIT {
       .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
       .withRequestBody(equalToJson(asJsonString(checkOutDryRunRequest)))
       .willReturn(jsonResponse(asJsonString(checkOutDryRunResponse), HttpStatus.SC_CREATED)));
+
     LoanPolicy loanPolicy = new LoanPolicy().id(loanPolicyId).name("test loanPolicy");
     wireMockServer.stubFor(get(urlEqualTo(LOAN_POLICY_STORAGE_URL + "/" + loanPolicyId))
       .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))

--- a/src/test/java/org/folio/api/CheckOutApiTest.java
+++ b/src/test/java/org/folio/api/CheckOutApiTest.java
@@ -79,6 +79,7 @@ class CheckOutApiTest extends BaseIT {
     wireMockServer.stubFor(get(urlEqualTo(LOAN_POLICY_STORAGE_URL + "/" + loanPolicyId))
       .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
       .willReturn(jsonResponse(asJsonString(loanPolicy), HttpStatus.SC_OK)));
+
     LoanPolicy clonedLoanPolicy = loanPolicy.name("COPY_OF_" + loanPolicy.getName());
     wireMockServer.stubFor(post(urlEqualTo(LOAN_POLICY_STORAGE_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))

--- a/src/test/java/org/folio/api/CheckOutApiTest.java
+++ b/src/test/java/org/folio/api/CheckOutApiTest.java
@@ -66,10 +66,12 @@ class CheckOutApiTest extends BaseIT {
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .withRequestBody(equalToJson(asJsonString(checkOutRequest)))
       .willReturn(jsonResponse(asJsonString(checkOutResponse), HttpStatus.SC_OK)));
+
     wireMockServer.stubFor(post(urlEqualTo(SEARCH_ITEMS_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .withRequestBody(equalToJson(asJsonString(itemsSearchRequest)))
       .willReturn(jsonResponse(asJsonString(itemsSearchResponse), HttpStatus.SC_OK)));
+
     wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
       .withRequestBody(equalToJson(asJsonString(checkOutDryRunRequest)))

--- a/src/test/java/org/folio/api/CheckOutApiTest.java
+++ b/src/test/java/org/folio/api/CheckOutApiTest.java
@@ -3,6 +3,8 @@ package org.folio.api;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -16,10 +18,13 @@ import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.folio.domain.dto.BatchIds;
+import org.folio.domain.dto.CheckOutDryRunRequest;
+import org.folio.domain.dto.CheckOutDryRunResponse;
 import org.folio.domain.dto.CheckOutRequest;
 import org.folio.domain.dto.CheckOutResponse;
 import org.folio.domain.dto.ConsortiumItem;
 import org.folio.domain.dto.ConsortiumItems;
+import org.folio.domain.dto.LoanPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,6 +34,8 @@ class CheckOutApiTest extends BaseIT {
 
   private static final String CHECK_OUT_URL = "/tlr/loans/check-out-by-barcode";
   private static final String CIRCULATION_CHECK_OUT_URL = "/circulation/check-out-by-barcode";
+  private static final String CIRCULATION_CHECK_OUT_DRY_RUN_URL = "/circulation/check-out-by-barcode-dry-run";
+  private static final String LOAN_POLICY_STORAGE_URL = "/loan-policy-storage/loan-policies";
   private static final String SEARCH_ITEMS_URL = "/search/consortium/batch/items";
 
   private static final String ITEM_ID = randomId();
@@ -39,8 +46,11 @@ class CheckOutApiTest extends BaseIT {
 
   @Test
   void checkOutSuccess() {
-    CheckOutRequest checkOutRequest = buildCheckoutRequest();
+    String loanPolicyId = randomId();
+    CheckOutRequest checkOutRequest = buildCheckoutRequest(loanPolicyId);
+    CheckOutDryRunRequest checkOutDryRunRequest = buildCheckoutDryRunRequest();
     CheckOutResponse checkOutResponse = buildCheckOutResponse();
+    CheckOutDryRunResponse checkOutDryRunResponse = buildCheckoutDryRunResponse(loanPolicyId);
 
     wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))
@@ -63,19 +73,41 @@ class CheckOutApiTest extends BaseIT {
       .withRequestBody(equalToJson(asJsonString(itemsSearchRequest)))
       .willReturn(jsonResponse(asJsonString(itemsSearchResponse), HttpStatus.SC_OK)));
 
+    wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
+      .withRequestBody(equalToJson(asJsonString(checkOutDryRunRequest)))
+      .willReturn(jsonResponse(asJsonString(checkOutDryRunResponse), HttpStatus.SC_CREATED)));
+
+    LoanPolicy loanPolicy = new LoanPolicy().id(loanPolicyId).name("test loanPolicy");
+    wireMockServer.stubFor(get(urlEqualTo(LOAN_POLICY_STORAGE_URL + "/" + loanPolicyId))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
+      .willReturn(jsonResponse(asJsonString(loanPolicy), HttpStatus.SC_OK)));
+
+    LoanPolicy clonedLoanPolicy = loanPolicy.name("COPY_OF_" + loanPolicy.getName());
+    wireMockServer.stubFor(post(urlEqualTo(LOAN_POLICY_STORAGE_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))
+      .withRequestBody(equalToJson(asJsonString(loanPolicy.name(clonedLoanPolicy.getName()))))
+      .willReturn(jsonResponse(asJsonString(clonedLoanPolicy), HttpStatus.SC_OK)));
+
     checkOut(checkOutRequest)
       .expectStatus().isOk();
 
     wireMockServer.verify(postRequestedFor(urlEqualTo(CIRCULATION_CHECK_OUT_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM)));
-
+    wireMockServer.verify(postRequestedFor(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE)));
+    wireMockServer.verify(getRequestedFor(urlEqualTo(LOAN_POLICY_STORAGE_URL + "/" + loanPolicyId))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE)));
+    wireMockServer.verify(postRequestedFor(urlEqualTo(LOAN_POLICY_STORAGE_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM)));
     wireMockServer.verify(postRequestedFor(urlEqualTo(SEARCH_ITEMS_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM)));
   }
 
   @Test
   void checkOutFailsIfItemIsNotFound() {
-    CheckOutRequest checkOutRequest = buildCheckoutRequest();
+    String loanPolicyId = randomId();
+    CheckOutRequest checkOutRequest = buildCheckoutRequest(loanPolicyId);
 
     BatchIds itemsSearchRequest = new BatchIds()
       .identifierType(BatchIds.IdentifierTypeEnum.BARCODE)
@@ -100,11 +132,13 @@ class CheckOutApiTest extends BaseIT {
   @ParameterizedTest
   @ValueSource(ints = { 400, 422, 500 })
   void circulationCheckOutErrorsAreForwarded(int statusCode) {
-    CheckOutRequest checkOutRequest = buildCheckoutRequest();
+    String loanPolicyId = randomId();
+    CheckOutRequest checkOutRequest = buildCheckoutRequest(loanPolicyId);
+    CheckOutDryRunRequest checkOutDryRunRequest = buildCheckoutDryRunRequest();
 
     BatchIds itemsSearchRequest = new BatchIds()
       .identifierType(BatchIds.IdentifierTypeEnum.BARCODE)
-      .identifierValues(List.of(checkOutRequest.getItemBarcode()));
+      .identifierValues(List.of(checkOutDryRunRequest.getItemBarcode()));
 
     ConsortiumItems itemsSearchResponse = new ConsortiumItems()
       .totalRecords(1)
@@ -118,9 +152,9 @@ class CheckOutApiTest extends BaseIT {
       .withRequestBody(equalToJson(asJsonString(itemsSearchRequest)))
       .willReturn(jsonResponse(asJsonString(itemsSearchResponse), HttpStatus.SC_OK)));
 
-    wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_URL))
-      .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .withRequestBody(equalToJson(asJsonString(checkOutRequest)))
+    wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE))
+      .withRequestBody(equalToJson(asJsonString(checkOutDryRunRequest)))
       .willReturn(aResponse().withStatus(statusCode).withBody("Status code is " + statusCode)));
 
     checkOut(checkOutRequest)
@@ -130,14 +164,21 @@ class CheckOutApiTest extends BaseIT {
     wireMockServer.verify(postRequestedFor(urlEqualTo(SEARCH_ITEMS_URL))
       .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM)));
 
-    wireMockServer.verify(postRequestedFor(urlEqualTo(CIRCULATION_CHECK_OUT_URL))
-      .withHeader(TENANT, equalTo(TENANT_ID_CONSORTIUM)));
+    wireMockServer.verify(postRequestedFor(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
+      .withHeader(TENANT, equalTo(TENANT_ID_COLLEGE)));
   }
 
-  private static CheckOutRequest buildCheckoutRequest() {
+  private static CheckOutRequest buildCheckoutRequest(String loanPolicyId) {
     return new CheckOutRequest()
       .itemBarcode(ITEM_BARCODE)
       .servicePointId(SERVICE_POINT_ID)
+      .userBarcode(USER_BARCODE)
+      .forceLoanPolicyId(UUID.fromString(loanPolicyId));
+  }
+
+  private static CheckOutDryRunRequest buildCheckoutDryRunRequest() {
+    return new CheckOutDryRunRequest()
+      .itemBarcode(ITEM_BARCODE)
       .userBarcode(USER_BARCODE);
   }
 
@@ -146,6 +187,14 @@ class CheckOutApiTest extends BaseIT {
       .id(randomId())
       .itemId(ITEM_ID)
       .userId(USER_ID);
+  }
+
+  private CheckOutDryRunResponse buildCheckoutDryRunResponse(String loanPolicyId) {
+    return new CheckOutDryRunResponse()
+      .loanPolicyId(loanPolicyId)
+      .overdueFinePolicyId(randomId())
+      .lostItemPolicyId(randomId())
+      .patronNoticePolicyId(randomId());
   }
 
   private WebTestClient.ResponseSpec checkOut(CheckOutRequest request) {


### PR DESCRIPTION
## Purpose
New endpoint GET /tlr/loans/check-out-by-barcode, in addition to what’s implemented in https://folio-org.atlassian.net/browse/MODTLR-151, needs to:

Call check out dry run mod-circulation in that data tenant to define a loan policy to be copied (dependency - https://folio-org.atlassian.net/browse/CIRC-2266)

Call mod-circulation-storage in that data tenant to retrieve a loan policy by UUID

Call mod-circulation-storage in the Central tenant to store loan policy in Central tenant’s mod-circulation-storage

Same UUID

Add prefix to the loan policy name to highlight it’s a copy (CLONE_ ?)

Call mod-circulation to perform check out and force cloned policy (dependency - https://folio-org.atlassian.net/browse/CIRC-2267)

Resolves: [MODTLR-152](https://folio-org.atlassian.net/browse/MODTLR-152)