### PR TITLE
MODTLR-162 Fix issue with creating ECS request for Paged item

### DIFF
--- a/src/main/java/org/folio/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RequestServiceImpl.java
@@ -225,7 +225,7 @@ public class RequestServiceImpl implements RequestService {
 
     var item = getItemFromStorage(itemId, inventoryTenantId);
     var itemStatus = item.getStatus().getName();
-    var circulationItemStatus = defineCirculationItemStatus(itemStatus);
+    var circulationItemStatus = defineCirculationItemStatus(itemStatus, request.getRequestType());
     log.info("createCirculationItem:: item status {}, calculated status: {}",
       itemStatus, circulationItemStatus);
 
@@ -271,9 +271,9 @@ public class RequestServiceImpl implements RequestService {
   }
 
   private CirculationItemStatus.NameEnum defineCirculationItemStatus(
-    ItemStatus.NameEnum itemStatus) {
+    ItemStatus.NameEnum itemStatus, Request.RequestTypeEnum requestType) {
 
-    return itemStatus == ItemStatus.NameEnum.PAGED
+    return itemStatus == ItemStatus.NameEnum.PAGED && requestType == Request.RequestTypeEnum.PAGE
       ? CirculationItemStatus.NameEnum.AVAILABLE
       : CirculationItemStatus.NameEnum.fromValue(itemStatus.getValue());
   }

--- a/src/test/java/org/folio/service/RequestServiceTest.java
+++ b/src/test/java/org/folio/service/RequestServiceTest.java
@@ -111,7 +111,7 @@ class RequestServiceTest {
 
     CirculationItem expectedCirculationItem = new CirculationItem()
       .status(new CirculationItemStatus()
-        .name(CirculationItemStatus.NameEnum.AVAILABLE))
+        .name(CirculationItemStatus.NameEnum.PAGED))
       .id(UUID.fromString(ITEM_ID))
       .holdingsRecordId(UUID.fromString(HOLDINGS_RECORD_ID))
       .dcbItem(true)


### PR DESCRIPTION
## Purpose
Problem: When attempting to place an ILR Hold on an Item that is already Paged, User receives a error message "This request was not placed successfully".

Preconditions:

A Page was already created for this Item.

Steps to reproduce:

From the Central tenant:

Place an ILR on an available Item (e.g., onsite general collections)

Immediately place a Hold on that same Item for a different User

Expected result: ECS Request created

Actual result: User gets an error; Secondary request is created

Resolves: [MODTLR-162](https://folio-org.atlassian.net/browse/MODTLR-162)
