### PR TITLE
MODTLR-176: Increase memory allocation

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -458,7 +458,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 1073741824,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
## Purpose
Increase module's memory allocation to 1gb to try and fix module's failure during platform-complete builds.
[MODTLR-176](https://folio-org.atlassian.net/browse/MODTLR-176)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
