### PR TITLE
MODTLR-150: Remove `patronGroup` from request schema

### DIFF
--- a/src/main/resources/swagger.api/schemas/request.json
+++ b/src/main/resources/swagger.api/schemas/request.json
@@ -156,10 +156,6 @@
         "barcode": {
           "description": "barcode of the requesting patron",
           "type": "string"
-        },
-        "patronGroup" : {
-          "description": "DEPRECATED, to be removed in subsequent major version",
-          "type": "string"
         }
       },
       "additionalProperties": true
@@ -182,10 +178,6 @@
         },
         "barcode": {
           "description": "barcode of the proxy patron",
-          "type": "string"
-        },
-        "patronGroup": {
-          "description": "DEPRECATED, to be removed in subsequent major version",
           "type": "string"
         }
       },


### PR DESCRIPTION
## Purpose
`RequestBatchUpdateEventHandler` deserializes requests in the request queue using mod-circulatin-storage's schema, while these requests are built according to mod-circulation's extended request schema. Currently, deserialization of such requets fails, because 
mod-tlr expects property `patronGroup` to be a string (according to mod-circulation-storage schema), while in fact is is an object (according to mod-circulation's request schema). 

https://folio-org.atlassian.net/browse/MODTLR-150

## Approach
Ideally, we need to use mod-circulation's request schema to deserialize request queue, but a much quicker and easier solution is to just remove patron group from the existing schema.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
