### PR TITLE
MODTLR-296 Extend loan actions with check-in after claim returned

### DIFF
--- a/src/main/java/org/folio/service/impl/LoanEventHandler.java
+++ b/src/main/java/org/folio/service/impl/LoanEventHandler.java
@@ -11,6 +11,7 @@ import static org.folio.support.kafka.EventType.UPDATE;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.folio.client.LoanStorageClient;
@@ -37,7 +38,8 @@ import lombok.extern.log4j.Log4j2;
 @Service
 @Log4j2
 public class LoanEventHandler implements KafkaEventHandler<Loan> {
-  private static final String LOAN_ACTION_CHECKED_IN = "checkedin";
+  private static final Set<String> LOAN_ACTIONS_CHECK_IN = Set.of(
+    "checkedin", "checkedInReturnedByPatron", "checkedInFoundByLibrary");
   private static final EnumSet<TransactionStatusResponse.StatusEnum>
     RELEVANT_TRANSACTION_STATUSES_FOR_CHECK_IN = EnumSet.of(ITEM_CHECKED_OUT, ITEM_CHECKED_IN, CLOSED);
 
@@ -68,7 +70,7 @@ public class LoanEventHandler implements KafkaEventHandler<Loan> {
     Loan loan = event.getNewVersion();
     String loanAction = loan.getAction();
     log.info("handle:: loan action: {}", loanAction);
-    if (LOAN_ACTION_CHECKED_IN.equals(loanAction)) {
+    if (LOAN_ACTIONS_CHECK_IN.contains(loanAction)) {
       log.info("handleUpdateEvent:: processing loan check-in event: {}", event::getId);
       handleCheckInEvent(event);
     } else {

--- a/src/test/java/org/folio/service/LoanEventHandlerTest.java
+++ b/src/test/java/org/folio/service/LoanEventHandlerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -192,6 +193,76 @@ class LoanEventHandlerTest {
 
     verify(ecsTlrRepository).findByItemId(itemId);
     verifyNoInteractions(dcbService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"checkedInReturnedByPatron", "checkedInFoundByLibrary"})
+  void claimResolvedCheckInEventIsIgnoredWhenEcsTlrForUpdatedLoanIsNotFound(String loanAction) {
+    UUID itemId = randomUUID();
+    Loan loan = new Loan()
+      .id(randomUUID().toString())
+      .action(loanAction)
+      .itemId(itemId.toString())
+      .userId(randomUUID().toString());
+
+    when(ecsTlrRepository.findByItemId(itemId)).thenReturn(emptyList());
+
+    loanEventHandler.handle(createEvent(loan));
+
+    verify(ecsTlrRepository).findByItemId(itemId);
+    verifyNoInteractions(dcbService);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "checkedInReturnedByPatron, BORROWING-PICKUP, ITEM_CHECKED_OUT, LENDER, ITEM_CHECKED_OUT, borrowing_tenant, ITEM_CHECKED_IN",
+    "checkedInReturnedByPatron, BORROWING-PICKUP, ITEM_CHECKED_IN, LENDER, ITEM_CHECKED_IN, lending_tenant, CLOSED",
+    "checkedInFoundByLibrary, PICKUP, ITEM_CHECKED_OUT, LENDER, ITEM_CHECKED_OUT, borrowing_tenant, ITEM_CHECKED_IN",
+    "checkedInFoundByLibrary, PICKUP, ITEM_CHECKED_IN, LENDER, CLOSED, lending_tenant, CLOSED"
+  })
+  void claimResolvedCheckInEventIsHandled(String loanAction, String primaryTransactionRole,
+    String primaryTransactionStatus, String secondaryTransactionRole, String secondaryTransactionStatus,
+    String eventTenant, String expectedNewTransactionStatus) {
+
+    String primaryRequestTenant = "borrowing_tenant";
+    String secondaryRequestTenant = "lending_tenant";
+    UUID primaryTransactionId = randomUUID();
+    UUID secondaryTransactionId = randomUUID();
+    UUID itemId = randomUUID();
+    Loan loan = new Loan()
+      .action(loanAction)
+      .itemId(itemId.toString())
+      .userId(randomUUID().toString());
+
+    EcsTlrEntity mockEcsTlr = new EcsTlrEntity();
+    mockEcsTlr.setId(randomUUID());
+    mockEcsTlr.setPrimaryRequestTenantId(primaryRequestTenant);
+    mockEcsTlr.setSecondaryRequestTenantId(secondaryRequestTenant);
+    mockEcsTlr.setPrimaryRequestDcbTransactionId(primaryTransactionId);
+    mockEcsTlr.setSecondaryRequestDcbTransactionId(secondaryTransactionId);
+
+    when(ecsTlrRepository.findByItemId(itemId)).thenReturn(List.of(mockEcsTlr));
+    when(dcbService.getTransactionStatus(primaryTransactionId, primaryRequestTenant))
+      .thenReturn(buildTransactionStatusResponse(primaryTransactionRole, primaryTransactionStatus));
+    when(dcbService.getTransactionStatus(secondaryTransactionId, secondaryRequestTenant))
+      .thenReturn(buildTransactionStatusResponse(secondaryTransactionRole, secondaryTransactionStatus));
+
+    TransactionStatus.StatusEnum expectedNewStatus = TransactionStatus.StatusEnum.fromValue(
+      expectedNewTransactionStatus);
+    doNothing().when(dcbService).updateTransactionStatuses(expectedNewStatus, mockEcsTlr);
+
+    KafkaEvent<Loan> event = new DefaultKafkaEvent<>(randomUUID().toString(), eventTenant,
+      DefaultKafkaEvent.DefaultKafkaEventType.UPDATED, 0L,
+      new DefaultKafkaEvent.DefaultKafkaEventData<>(loan, loan))
+      .withTenantIdHeaderValue(eventTenant)
+      .withUserIdHeaderValue("random_user_id");
+
+    loanEventHandler.handle(event);
+
+    verify(ecsTlrRepository).findByItemId(itemId);
+    verify(dcbService).getTransactionStatus(primaryTransactionId, primaryRequestTenant);
+    verify(dcbService).getTransactionStatus(secondaryTransactionId, secondaryRequestTenant);
+    verify(dcbService).updateTransactionStatuses(expectedNewStatus, mockEcsTlr);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Purpose
Resolves: [MODTLR-296](https://folio-org.atlassian.net/browse/MODTLR-296)
