### PR TITLE
MODTLR-312: Propagate real cancellation reason to Member tenant for shared/consortium reasons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.3.0-SNAPSHOT
+* Propagate real cancellation reason to Member tenant for shared/consortium reasons (MODTLR-312)
+
 ## 1.2.0 2026-04-15
 * Increase memory allocation to 1 GB (MODTLR-176)
 * Fix issue with creating ECS request for Paged item (MODTLR-162)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -430,6 +430,10 @@
       "version": "3.4"
     },
     {
+      "id": "cancellation-reason-storage",
+      "version": "1.2"
+    },
+    {
       "id": "ecs-request-transactions",
       "version": "1.0"
     },
@@ -476,6 +480,7 @@
         "inventory-storage.service-points.item.get",
         "inventory-storage.service-points.collection.get",
         "inventory-storage.service-points.item.post",
+        "circulation-storage.cancellation-reasons.item.get",
         "dcb.ecs-request.transactions.post",
         "circulation.requests.allowed-service-points.get",
         "dcb.transactions.status.get",

--- a/src/main/java/org/folio/client/CancellationReasonClient.java
+++ b/src/main/java/org/folio/client/CancellationReasonClient.java
@@ -1,0 +1,13 @@
+package org.folio.client;
+
+import org.folio.domain.dto.CancellationReason;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange(url = "cancellation-reason-storage/cancellation-reasons")
+public interface CancellationReasonClient {
+
+  @GetExchange("/{id}")
+  CancellationReason getCancellationReason(@PathVariable String id);
+}

--- a/src/main/java/org/folio/client/config/HttpClientConfiguration.java
+++ b/src/main/java/org/folio/client/config/HttpClientConfiguration.java
@@ -1,6 +1,7 @@
 package org.folio.client.config;
 
 import org.folio.client.AddressTypeClient;
+import org.folio.client.CancellationReasonClient;
 import org.folio.client.CheckOutClient;
 import org.folio.client.CirculationClient;
 import org.folio.client.CirculationErrorForwardingClient;
@@ -53,6 +54,12 @@ public class HttpClientConfiguration {
   public AddressTypeClient addressTypeClient(
     @Qualifier("httpServiceProxyFactory") HttpServiceProxyFactory factory) {
     return factory.createClient(AddressTypeClient.class);
+  }
+
+  @Bean
+  public CancellationReasonClient cancellationReasonClient(
+    @Qualifier("errorForwardingHttpServiceProxyFactory") HttpServiceProxyFactory factory) {
+    return factory.createClient(CancellationReasonClient.class);
   }
 
   @Bean

--- a/src/main/java/org/folio/service/CancellationReasonService.java
+++ b/src/main/java/org/folio/service/CancellationReasonService.java
@@ -1,0 +1,7 @@
+package org.folio.service;
+
+import org.folio.domain.dto.CancellationReason;
+
+public interface CancellationReasonService {
+  CancellationReason find(String id);
+}

--- a/src/main/java/org/folio/service/impl/CancellationReasonServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/CancellationReasonServiceImpl.java
@@ -1,0 +1,25 @@
+package org.folio.service.impl;
+
+import org.folio.client.CancellationReasonClient;
+import org.folio.domain.dto.CancellationReason;
+import org.folio.service.CancellationReasonService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CancellationReasonServiceImpl implements CancellationReasonService {
+
+  private final CancellationReasonClient cancellationReasonClient;
+
+  @Override
+  public CancellationReason find(String cancellationReasonId) {
+    log.info("find:: looking up cancellation reason {}", cancellationReasonId);
+    CancellationReason cancellationReason = cancellationReasonClient.getCancellationReason(cancellationReasonId);
+    log.info("find:: found cancellation reason {}", cancellationReasonId);
+    return cancellationReason;
+  }
+}

--- a/src/main/java/org/folio/service/impl/RequestEventHandler.java
+++ b/src/main/java/org/folio/service/impl/RequestEventHandler.java
@@ -18,12 +18,14 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.domain.dto.CancellationReason;
 import org.folio.domain.dto.Request;
 import org.folio.domain.dto.Request.EcsRequestPhaseEnum;
 import org.folio.domain.dto.Request.FulfillmentPreferenceEnum;
 import org.folio.domain.dto.ServicePoint;
 import org.folio.domain.entity.EcsTlrEntity;
 import org.folio.repository.EcsTlrRepository;
+import org.folio.service.CancellationReasonService;
 import org.folio.service.CloningService;
 import org.folio.service.DcbService;
 import org.folio.service.KafkaEventHandler;
@@ -43,6 +45,8 @@ import lombok.extern.log4j.Log4j2;
 public class RequestEventHandler implements KafkaEventHandler<Request> {
   // the id used by DCB when canceling a request
   private static final String DCB_CANCELLATION_REASON_ID = "50ed35b2-1397-4e83-a76b-642adf91ca2a";
+  // source of a cancellation reason record that is shared across all tenants in the consortium
+  private static final String CONSORTIUM_SOURCE = "Consortium";
 
   private final DcbService dcbService;
   private final EcsTlrRepository ecsTlrRepository;
@@ -51,6 +55,7 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
   private final ServicePointService servicePointService;
   private final CloningService<ServicePoint> servicePointCloningService;
   private final RequestService requestService;
+  private final CancellationReasonService cancellationReasonService;
 
   @Override
   public void handle(KafkaEvent<Request> event) {
@@ -257,7 +262,7 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
       targetRequest.setCancelledDate(new Date());
       targetRequest.setCancellationAdditionalInformation("Request cancelled by DCB");
       targetRequest.setCancelledByUserId(event.getUserIdHeaderValue());
-      targetRequest.setCancellationReasonId(DCB_CANCELLATION_REASON_ID);
+      targetRequest.setCancellationReasonId(resolveCancellationReasonId(ecsTlr, primaryRequest));
       shouldUpdateTargetRequest = true;
     }
 
@@ -284,6 +289,42 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
       primaryRequestTenantId, folioContext, () -> servicePointService.find(pickupServicePointId));
     contextService.execute(targetRequestTenantId, folioContext,
       () -> servicePointCloningService.clone(pickupServicePoint));
+  }
+
+  private String resolveCancellationReasonId(EcsTlrEntity ecsTlr, Request primaryRequest) {
+    String cancellationReasonId = primaryRequest.getCancellationReasonId();
+    if (StringUtils.isBlank(cancellationReasonId)) {
+      log.info("resolveCancellationReasonId:: primary request has no cancellation reason ID, " +
+        "falling back to DCB cancellation reason");
+      return DCB_CANCELLATION_REASON_ID;
+    }
+
+    log.info("resolveCancellationReasonId:: looking up cancellation reason {}", cancellationReasonId);
+    CancellationReason cancellationReason;
+    try {
+      cancellationReason = contextService.execute(ecsTlr.getPrimaryRequestTenantId(), folioContext,
+        () -> cancellationReasonService.find(cancellationReasonId));
+    } catch (Exception e) {
+      log.error("resolveCancellationReasonId:: failed to look up cancellation reason {}, " +
+        "falling back to DCB cancellation reason", cancellationReasonId, e);
+      return DCB_CANCELLATION_REASON_ID;
+    }
+
+    if (cancellationReason == null) {
+      log.warn("resolveCancellationReasonId:: cancellation reason {} not found, " +
+        "falling back to DCB cancellation reason", cancellationReasonId);
+      return DCB_CANCELLATION_REASON_ID;
+    }
+
+    if (CONSORTIUM_SOURCE.equalsIgnoreCase(cancellationReason.getSource())) {
+      log.info("resolveCancellationReasonId:: cancellation reason {} is shared across the consortium, " +
+        "using the real cancellation reason ID", cancellationReasonId);
+      return cancellationReasonId;
+    }
+
+    log.info("resolveCancellationReasonId:: cancellation reason {} is not shared across the consortium, " +
+      "falling back to DCB cancellation reason", cancellationReasonId);
+    return DCB_CANCELLATION_REASON_ID;
   }
 
   private boolean needToCancelHoldTlr(Request primaryRequest, Request targetRequest) {

--- a/src/main/resources/permissions/mod-tlr.csv
+++ b/src/main/resources/permissions/mod-tlr.csv
@@ -26,6 +26,7 @@ circulation-storage.loans.item.put
 inventory-storage.service-points.item.get
 inventory-storage.service-points.collection.get
 inventory-storage.service-points.item.post
+circulation-storage.cancellation-reasons.item.get
 dcb.ecs-request.transactions.post
 circulation.requests.allowed-service-points.get
 dcb.transactions.status.get

--- a/src/main/resources/swagger.api/ecs-tlr.yaml
+++ b/src/main/resources/swagger.api/ecs-tlr.yaml
@@ -127,6 +127,8 @@ components:
       $ref: 'schemas/inventory/servicePoint.json'
     userGroup:
       $ref: 'schemas/users/userGroup.json'
+    cancellationReason:
+      $ref: 'schemas/circulation-storage/cancellation-reason.json'
     requestsBatchUpdate:
       $ref: 'schemas/requests-batch-update.json'
     reorderQueue:

--- a/src/main/resources/swagger.api/schemas/circulation-storage/cancellation-reason.json
+++ b/src/main/resources/swagger.api/schemas/circulation-storage/cancellation-reason.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Cancellation reason",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Id of the cancellation reason record"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the cancellation reason"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the cancellation reason"
+    },
+    "publicDescription": {
+      "type": "string",
+      "description": "Public description of the cancellation reason"
+    },
+    "requiresAdditionalInformation": {
+      "type": "boolean",
+      "description": "Indicates if additional information is required when this reason is used"
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the cancellation reason record, e.g. 'System', 'User', 'Consortium' etc."
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../metadata.json",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "name"
+  ]
+}

--- a/src/test/java/org/folio/service/RequestEventHandlerTest.java
+++ b/src/test/java/org/folio/service/RequestEventHandlerTest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.folio.domain.dto.CancellationReason;
 import org.folio.domain.dto.Request;
 import org.folio.domain.dto.ServicePoint;
 import org.folio.domain.entity.EcsTlrEntity;
@@ -47,6 +48,8 @@ class RequestEventHandlerTest {
   private static final String PRIMARY_REQUEST_TENANT_ID = "primary_tenant";
   private static final String SECONDARY_REQUEST_TENANT_ID = "secondary_tenant";
   private static final String INTERMEDIATE_REQUEST_TENANT_ID = "intermediate_tenant";
+  // the id used by DCB when canceling a request, must match RequestEventHandler.DCB_CANCELLATION_REASON_ID
+  private static final String DCB_CANCELLATION_REASON_ID = "50ed35b2-1397-4e83-a76b-642adf91ca2a";
 
   @Mock
   private DcbService dcbService;
@@ -62,6 +65,8 @@ class RequestEventHandlerTest {
   private FolioExecutionContext folioContext;
   @Mock
   private CloningService<ServicePoint> servicePointCloningService;
+  @Mock
+  private CancellationReasonService cancellationReasonService;
 
   @InjectMocks
   private RequestEventHandler handler;
@@ -208,6 +213,138 @@ class RequestEventHandlerTest {
     verify(requestService).updateRequestInStorage(requestCaptor.capture(), eq(SECONDARY_REQUEST_TENANT_ID));
     Request updatedSecondaryRequest = requestCaptor.getValue();
     assertThat(updatedSecondaryRequest.getStatus(), is(CLOSED_CANCELLED));
+  }
+
+  @Test
+  void sharedCancellationReasonIdIsPropagatedAsIsToTargetRequest() {
+    String cancellationReasonId = randomId();
+    EcsTlrEntity ecsTlr = buildEcsTlr();
+    Request primaryRequest = new Request()
+      .id(PRIMARY_REQUEST_ID.toString())
+      .ecsRequestPhase(PRIMARY)
+      .requestLevel(Request.RequestLevelEnum.TITLE)
+      .requestType(Request.RequestTypeEnum.HOLD)
+      .status(CLOSED_CANCELLED)
+      .cancellationReasonId(cancellationReasonId);
+    Request secondaryRequest = new Request()
+      .id(SECONDARY_REQUEST_ID.toString())
+      .ecsRequestPhase(SECONDARY)
+      .status(Request.StatusEnum.OPEN_IN_TRANSIT);
+
+    mockFolioExecutionContextService(contextService);
+    when(ecsTlrRepository.findBySecondaryRequestId(PRIMARY_REQUEST_ID))
+      .thenReturn(Optional.of(ecsTlr));
+    when(requestService.getRequestFromStorage(SECONDARY_REQUEST_ID.toString(), SECONDARY_REQUEST_TENANT_ID))
+      .thenReturn(secondaryRequest);
+    when(cancellationReasonService.find(cancellationReasonId))
+      .thenReturn(new CancellationReason().id(cancellationReasonId).name("Shared reason").source("Consortium"));
+
+    KafkaEvent<Request> event = buildRequestUpdateEvent(primaryRequest, primaryRequest,
+      PRIMARY_REQUEST_TENANT_ID);
+    handler.handle(event);
+
+    verify(requestService).updateRequestInStorage(requestCaptor.capture(), eq(SECONDARY_REQUEST_TENANT_ID));
+    Request updatedSecondaryRequest = requestCaptor.getValue();
+    assertThat(updatedSecondaryRequest.getStatus(), is(CLOSED_CANCELLED));
+    assertThat(updatedSecondaryRequest.getCancellationReasonId(), is(cancellationReasonId));
+  }
+
+  @Test
+  void nonSharedCancellationReasonIdFallsBackToDcbCancellationReasonId() {
+    String cancellationReasonId = randomId();
+    EcsTlrEntity ecsTlr = buildEcsTlr();
+    Request primaryRequest = new Request()
+      .id(PRIMARY_REQUEST_ID.toString())
+      .ecsRequestPhase(PRIMARY)
+      .requestLevel(Request.RequestLevelEnum.TITLE)
+      .requestType(Request.RequestTypeEnum.HOLD)
+      .status(CLOSED_CANCELLED)
+      .cancellationReasonId(cancellationReasonId);
+    Request secondaryRequest = new Request()
+      .id(SECONDARY_REQUEST_ID.toString())
+      .ecsRequestPhase(SECONDARY)
+      .status(Request.StatusEnum.OPEN_IN_TRANSIT);
+
+    mockFolioExecutionContextService(contextService);
+    when(ecsTlrRepository.findBySecondaryRequestId(PRIMARY_REQUEST_ID))
+      .thenReturn(Optional.of(ecsTlr));
+    when(requestService.getRequestFromStorage(SECONDARY_REQUEST_ID.toString(), SECONDARY_REQUEST_TENANT_ID))
+      .thenReturn(secondaryRequest);
+    when(cancellationReasonService.find(cancellationReasonId))
+      .thenReturn(new CancellationReason().id(cancellationReasonId).name("Local reason").source("System"));
+
+    KafkaEvent<Request> event = buildRequestUpdateEvent(primaryRequest, primaryRequest,
+      PRIMARY_REQUEST_TENANT_ID);
+    handler.handle(event);
+
+    verify(requestService).updateRequestInStorage(requestCaptor.capture(), eq(SECONDARY_REQUEST_TENANT_ID));
+    Request updatedSecondaryRequest = requestCaptor.getValue();
+    assertThat(updatedSecondaryRequest.getStatus(), is(CLOSED_CANCELLED));
+    assertThat(updatedSecondaryRequest.getCancellationReasonId(), is(DCB_CANCELLATION_REASON_ID));
+  }
+
+  @Test
+  void cancellationReasonLookupFailureFallsBackToDcbCancellationReasonId() {
+    String cancellationReasonId = randomId();
+    EcsTlrEntity ecsTlr = buildEcsTlr();
+    Request primaryRequest = new Request()
+      .id(PRIMARY_REQUEST_ID.toString())
+      .ecsRequestPhase(PRIMARY)
+      .requestLevel(Request.RequestLevelEnum.TITLE)
+      .requestType(Request.RequestTypeEnum.HOLD)
+      .status(CLOSED_CANCELLED)
+      .cancellationReasonId(cancellationReasonId);
+    Request secondaryRequest = new Request()
+      .id(SECONDARY_REQUEST_ID.toString())
+      .ecsRequestPhase(SECONDARY)
+      .status(Request.StatusEnum.OPEN_IN_TRANSIT);
+
+    mockFolioExecutionContextService(contextService);
+    when(ecsTlrRepository.findBySecondaryRequestId(PRIMARY_REQUEST_ID))
+      .thenReturn(Optional.of(ecsTlr));
+    when(requestService.getRequestFromStorage(SECONDARY_REQUEST_ID.toString(), SECONDARY_REQUEST_TENANT_ID))
+      .thenReturn(secondaryRequest);
+    when(cancellationReasonService.find(cancellationReasonId))
+      .thenThrow(new RuntimeException("not found"));
+
+    KafkaEvent<Request> event = buildRequestUpdateEvent(primaryRequest, primaryRequest,
+      PRIMARY_REQUEST_TENANT_ID);
+    handler.handle(event);
+
+    verify(requestService).updateRequestInStorage(requestCaptor.capture(), eq(SECONDARY_REQUEST_TENANT_ID));
+    Request updatedSecondaryRequest = requestCaptor.getValue();
+    assertThat(updatedSecondaryRequest.getStatus(), is(CLOSED_CANCELLED));
+    assertThat(updatedSecondaryRequest.getCancellationReasonId(), is(DCB_CANCELLATION_REASON_ID));
+  }
+
+  @Test
+  void missingPrimaryCancellationReasonIdFallsBackToDcbCancellationReasonId() {
+    EcsTlrEntity ecsTlr = buildEcsTlr();
+    Request primaryRequest = new Request()
+      .id(PRIMARY_REQUEST_ID.toString())
+      .ecsRequestPhase(PRIMARY)
+      .requestLevel(Request.RequestLevelEnum.TITLE)
+      .requestType(Request.RequestTypeEnum.HOLD)
+      .status(CLOSED_CANCELLED);
+    Request secondaryRequest = new Request()
+      .id(SECONDARY_REQUEST_ID.toString())
+      .ecsRequestPhase(SECONDARY)
+      .status(Request.StatusEnum.OPEN_IN_TRANSIT);
+
+    when(ecsTlrRepository.findBySecondaryRequestId(PRIMARY_REQUEST_ID))
+      .thenReturn(Optional.of(ecsTlr));
+    when(requestService.getRequestFromStorage(SECONDARY_REQUEST_ID.toString(), SECONDARY_REQUEST_TENANT_ID))
+      .thenReturn(secondaryRequest);
+
+    KafkaEvent<Request> event = buildRequestUpdateEvent(primaryRequest, primaryRequest,
+      PRIMARY_REQUEST_TENANT_ID);
+    handler.handle(event);
+
+    verifyNoInteractions(cancellationReasonService);
+    verify(requestService).updateRequestInStorage(requestCaptor.capture(), eq(SECONDARY_REQUEST_TENANT_ID));
+    Request updatedSecondaryRequest = requestCaptor.getValue();
+    assertThat(updatedSecondaryRequest.getStatus(), is(CLOSED_CANCELLED));
+    assertThat(updatedSecondaryRequest.getCancellationReasonId(), is(DCB_CANCELLATION_REASON_ID));
   }
 
   private static KafkaEvent<Request> buildRequestUpdateEvent(Request oldVersion,

--- a/src/test/java/org/folio/service/impl/CancellationReasonServiceImplTest.java
+++ b/src/test/java/org/folio/service/impl/CancellationReasonServiceImplTest.java
@@ -1,0 +1,63 @@
+package org.folio.service.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.folio.client.CancellationReasonClient;
+import org.folio.domain.dto.CancellationReason;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CancellationReasonServiceImplTest {
+
+  private static final String CANCELLATION_REASON_ID = "50ed35b2-1397-4e83-a76b-642adf91ca2a";
+
+  @Mock
+  private CancellationReasonClient cancellationReasonClient;
+
+  @InjectMocks
+  private CancellationReasonServiceImpl cancellationReasonService;
+
+  @Test
+  void findReturnsCancellationReasonFetchedFromClient() {
+    CancellationReason cancellationReason = new CancellationReason()
+      .id(CANCELLATION_REASON_ID)
+      .name("Shared reason")
+      .source("Consortium");
+
+    when(cancellationReasonClient.getCancellationReason(CANCELLATION_REASON_ID))
+      .thenReturn(cancellationReason);
+
+    CancellationReason result = cancellationReasonService.find(CANCELLATION_REASON_ID);
+
+    assertThat(result, is(cancellationReason));
+    verify(cancellationReasonClient).getCancellationReason(CANCELLATION_REASON_ID);
+  }
+
+  @Test
+  void findReturnsNullWhenClientReturnsNull() {
+    when(cancellationReasonClient.getCancellationReason(CANCELLATION_REASON_ID))
+      .thenReturn(null);
+
+    CancellationReason result = cancellationReasonService.find(CANCELLATION_REASON_ID);
+
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  void findPropagatesExceptionThrownByClient() {
+    when(cancellationReasonClient.getCancellationReason(CANCELLATION_REASON_ID))
+      .thenThrow(new RuntimeException("not found"));
+
+    assertThrows(RuntimeException.class,
+      () -> cancellationReasonService.find(CANCELLATION_REASON_ID));
+  }
+}


### PR DESCRIPTION
## Purpose
When a primary Hold TLR is cancelled with a shared/consortium cancellation reason, the Member tenant's circulation log incorrectly showed "DCB Cancelled" instead of the real reason name.

## Approach
Added  CancellationReasonClient / Service  to fetch the primary request's cancellation reason from  cancellation-reason-storage . In  RequestEventHandler , look up the reason in the primary tenant's context; if its  source  is  "Consortium"  (case-insensitive), propagate the real  cancellationReasonId  to the target request — otherwise (non-shared, missing, or lookup failure) keep the existing  DCB_CANCELLATION_REASON_ID  fallback to avoid breaking the Member tenant's audit log.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
[MODTLR-312](https://folio-org.atlassian.net/browse/MODTLR-312)
